### PR TITLE
fix(helm): missing Temporal UI service annotations

### DIFF
--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -10,7 +10,7 @@ global:
   # Set to "" to use default storage class
   # Examples: gp2, standard, managed
   storageClass: ""
-  
+
   # -- Global image pull secrets for private container registries
   # List of Kubernetes secret names containing registry credentials
   # NOTE: Secrets must be created separately using kubectl or other means
@@ -22,7 +22,7 @@ global:
   #     - name: "my-registry-secret"
   #     - name: "docker-hub-secret"
   imagePullSecrets: []
-  
+
   # -- JobID-based node mapping configuration for pods created by olake-workers
   # Maps JobID (integer) to specific node labels for pod scheduling
   # Format: { jobID: { node_label: node_value } }
@@ -39,7 +39,7 @@ global:
   jobServiceAccount:
     create: false
     name: ""
-    
+
     # Used for cloud provider IAM role association
     # Examples:
     #   AWS IRSA: eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/olake-job-role"
@@ -51,17 +51,17 @@ global:
   # -- Global environment variables that apply to all OLake components
   # These variables are inherited by all services (olakeUI, olakeWorker)
   # Individual component env sections can override these values if needed
-  # 
+  #
   # OLAKE_SECRET_KEY: Used for encrypting job metadata and sensitive data
   #   - Leave empty or unset to disable encryption
   #   - Set to a secure random string. Example: "LewgLVrgCZMadJverZdn"
   #   - AWS KMS Key ARN can also be used. Example: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
-  # 
+  #
   # RUN_MODE: Sets the deployment environment mode
   #   - "development": Local development with debug features
-  #   - "staging": Pre-production testing environment  
+  #   - "staging": Pre-production testing environment
   #   - "production": Production deployment with optimizations
-  # 
+  #
   # Example configuration:
   #   env:
   #     OLAKE_SECRET_KEY: "your-secure-encryption-key-here"
@@ -72,35 +72,35 @@ global:
 olakeUI:
   # -- Number of OLake UI replicas
   replicaCount: 1
-  
+
   # -- OLake UI image configuration
   image:
     repository: olakego/ui
     tag: latest
     pullPolicy: Always
-  
+
   # -- Pod scheduling constraints
   nodeSelector: {}
-  
+
   # -- Tolerations for pod assignment
   tolerations: []
-  
+
   # -- Affinity settings for pod assignment
   affinity: {}
-  
+
   # -- Additional pod annotations
   podAnnotations: {}
-  
+
   # -- Additional pod labels
   podLabels: {}
-  
+
   # -- OLake UI service configuration
-  # For external access, change type to NodePort or LoadBalancer  
+  # For external access, change type to NodePort or LoadBalancer
   service:
     # -- Service type (ClusterIP for internal, NodePort/LoadBalancer for external access)
     type: ClusterIP
     annotations: {}
-  
+
   # -- OLake UI resource requirements (optional overrides)
   # Defaults: requests: memory=512Mi, cpu=500m (no limits by default)
   # Example customizations:
@@ -112,7 +112,7 @@ olakeUI:
   #       memory: "2Gi"
   #       cpu: "1500m"
   resources: {}
-  
+
   # -- Environment variables for OLake UI
   # Add custom environment variables here
   # Example:
@@ -120,16 +120,16 @@ olakeUI:
   #     CUSTOM_VAR: "value"
   #     FEATURE_FLAG: "true"
   env: {}
-  
+
   # -- Ingress configuration for external access
   ingress:
     # -- Enable ingress
     enabled: false
-    
+
     # -- Ingress class name
     # Examples: nginx, traefik, alb
     className: ""
-    
+
     # -- Ingress annotations
     # Add custom annotations for your ingress controller here.
     # Examples:
@@ -138,7 +138,7 @@ olakeUI:
     #   kubernetes.io/tls-acme: "true"
     #   cert-manager.io/cluster-issuer: "letsencrypt-prod"
     annotations: {}
-    
+
     # -- Ingress hosts configuration
     # List of host definitions for ingress. Each host can have multiple paths.
     # Examples:
@@ -152,7 +152,7 @@ olakeUI:
     #         - path: /
     #           pathType: Prefix
     hosts: []
-    
+
     # -- TLS configuration
     # Examples:
     #   tls:
@@ -160,7 +160,7 @@ olakeUI:
     #       hosts:
     #         - olake.example.com
     tls: []
-  
+
   # -- Initialization user configuration
   initUser:
     # -- Use an existing Kubernetes secret for the admin user credentials.
@@ -182,10 +182,10 @@ olakeUI:
     adminUser:
       # -- Admin username
       username: "admin"
-      
+
       # -- Admin password (change this in production!)
       password: "password"
-      
+
       # -- Admin email address
       email: "admin@example.com"
 
@@ -196,22 +196,22 @@ olakeWorker:
     repository: olakego/k8s-worker
     tag: latest
     pullPolicy: Always
-  
+
   # -- Pod scheduling constraints
   nodeSelector: {}
-  
+
   # -- Tolerations for pod assignment
   tolerations: []
-  
+
   # -- Affinity settings for pod assignment
   affinity: {}
-  
+
   # -- Additional pod annotations
   podAnnotations: {}
-  
+
   # -- Additional pod labels
   podLabels: {}
-  
+
   # -- OLake Worker resource requirements (optional overrides)
   # Defaults: requests: memory=256Mi, cpu=250m (no limits by default)
   # Example customizations:
@@ -223,7 +223,7 @@ olakeWorker:
   #       memory: "1Gi"
   #       cpu: "1000m"
   resources: {}
-  
+
   # -- Environment variables for OLake Worker
   # Add custom environment variables here
   # Example:
@@ -237,20 +237,20 @@ olakeWorker:
     # -- Service account name
     # If not set, a name is generated using the fullname template
     name: ""
-    
+
     # -- Service account annotations
     annotations: {}
-  
+
   # -- OLake Worker application configuration
   config:
     worker:
       # -- Maximum concurrent activities(https://docs.temporal.io/activities) per worker
       # Increase for higher throughput, decrease for resource constraints
       maxConcurrentActivities: 15
-      
+
       # -- Maximum concurrent workflows(https://docs.temporal.io/workflows) per worker
       maxConcurrentWorkflows: 10
-    
+
     # -- Timeout configuration for different operation types
     timeouts:
       # -- Activity execution timeouts
@@ -258,7 +258,7 @@ olakeWorker:
         discover: 2h
         test: 2h
         sync: 700h
-    
+
     # -- Logging configuration
     logging:
       level: info
@@ -274,43 +274,43 @@ nfsServer:
 
   # -- External storage configuration (used when enabled: false)
   # When disabled, you must provide an existing ReadWriteMany (RWX) PersistentVolumeClaim
-  # 
+  #
   # CLOUD PROVIDER GUIDES FOR RWX STORAGE:
-  # 
+  #
   # AWS EFS: Use the Amazon EFS CSI driver with 'efs.csi.aws.com' provisioner
   # See: https://github.com/kubernetes-sigs/aws-efs-csi-driver
-  # 
-  # Azure Files: Use 'azurefile' StorageClass with 'kubernetes.io/azure-file' provisioner  
+  #
+  # Azure Files: Use 'azurefile' StorageClass with 'kubernetes.io/azure-file' provisioner
   # See: https://docs.microsoft.com/en-us/azure/aks/azure-files-csi
-  # 
+  #
   # GCP Filestore: Use Google Cloud Filestore CSI driver with 'filestore.csi.storage.gke.io' provisioner
   # See: https://cloud.google.com/filestore/docs/csi-driver
   external:
     # -- The name of the PersistentVolumeClaim for the external RWX storage
     # Example: "efs-pvc" or "azure-files-pvc" or "gcp-filestore-pvc"
     name: ""
-  
-  
+
+
   # -- Pod scheduling constraints
   nodeSelector: {}
-  
+
   # -- Tolerations for pod assignment
   tolerations: []
-  
+
   # -- Affinity settings for pod assignment
   affinity: {}
-  
+
   # -- Additional pod annotations
   podAnnotations: {}
-  
+
   # -- Additional pod labels
   podLabels: {}
-  
+
   # -- Persistence configuration for NFS server backing storage
   persistence:
     # -- Size of backing storage for NFS server
     size: 20Gi
-  
+
   # -- StorageClass configuration for dynamic provisioning
   storageClass:
     # -- Name of the StorageClass created by NFS server
@@ -320,28 +320,28 @@ nfsServer:
 temporal:
   # -- Temporal server configuration
   server:
-    
+
     # -- Temporal server image configuration
     image:
       repository: temporalio/auto-setup
       tag: "1.22.3"
       pullPolicy: Always
-    
+
     # -- Pod scheduling constraints
     nodeSelector: {}
-    
+
     # -- Tolerations for pod assignment
     tolerations: []
-    
+
     # -- Affinity settings for pod assignment
     affinity: {}
-    
+
     # -- Additional pod annotations
     podAnnotations: {}
-    
+
     # -- Additional pod labels
     podLabels: {}
-    
+
     # -- Temporal server resource requirements (optional overrides)
     # Defaults: requests: memory=512Mi, cpu=500m (no limits by default)
     # Example customizations:
@@ -353,11 +353,19 @@ temporal:
     #       memory: "2Gi"
     #       cpu: "1500m"
     resources: {}
-  
+
+    # -- Temporal server service configuration
+    service:
+      annotations: {}
+
   # -- Temporal Web UI configuration (disabled by default)
   ui:
     # -- Enable Temporal Web UI
     enabled: false
+
+    # -- Temporal UI service configuration
+    service:
+      annotations: {}
 
 # PostgreSQL is used as the backend database for Temporal and OLake
 postgresql:
@@ -366,7 +374,7 @@ postgresql:
     repository: postgres
     tag: "14-alpine"
     pullPolicy: Always
-  
+
   # -- Authentication configuration
   auth:
     # -- PostgreSQL super user name
@@ -374,23 +382,23 @@ postgresql:
 
     # -- PostgreSQL super user password
     postgresPassword: "temporal"
-    
-  
+
+
   # -- Pod scheduling constraints
   nodeSelector: {}
-  
+
   # -- Tolerations for pod assignment
   tolerations: []
-  
+
   # -- Affinity settings for pod assignment
   affinity: {}
-  
+
   # -- Additional pod annotations
   podAnnotations: {}
-  
+
   # -- Additional pod labels
   podLabels: {}
-  
+
   # -- PostgreSQL resource requirements (optional overrides)
   # Defaults: requests: memory=256Mi, cpu=250m (no limits by default)
   # Example customizations:
@@ -402,7 +410,7 @@ postgresql:
   #       memory: "1Gi"
   #       cpu: "1000m"
   resources: {}
-  
+
   # -- PostgreSQL persistence configuration
   persistence:
     # -- Size of persistent volume for PostgreSQL data
@@ -415,22 +423,22 @@ elasticsearch:
     repository: elasticsearch
     tag: "7.17.10"
     pullPolicy: Always
-  
+
   # -- Pod scheduling constraints
   nodeSelector: {}
-  
+
   # -- Tolerations for pod assignment
   tolerations: []
-  
+
   # -- Affinity settings for pod assignment
   affinity: {}
-  
+
   # -- Additional pod annotations
   podAnnotations: {}
-  
+
   # -- Additional pod labels
   podLabels: {}
-  
+
   # -- Elasticsearch resource requirements (optional overrides)
   # Defaults: requests: memory=1Gi, cpu=500m (no limits by default)
   # Example customizations:
@@ -442,7 +450,7 @@ elasticsearch:
   #       memory: "4Gi"
   #       cpu: "2000m"
   resources: {}
-  
+
   # -- Elasticsearch persistence configuration
   persistence:
     # -- Size of persistent volume for Elasticsearch data


### PR DESCRIPTION
With current Helm chart default values: 

```shell
$ helm template . --set temporal.ui.enabled=true
Error: template: olake/templates/temporal/ui-service.yaml:7:19: executing "olake/templates/temporal/ui-service.yaml" at <.Values.temporal.ui.service.annotations>: nil pointer evaluating interface {}.annotations

Use --debug flag to render out invalid YAML
```

With this PR:

```yaml
$ helm template . --set temporal.ui.enabled=true
...
kind: Service
metadata:
  name: temporal-ui
  namespace: default
  labels:
    app.kubernetes.io/name: temporal-ui
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: workflow-ui
    app.kubernetes.io/name: olake
    app.kubernetes.io/managed-by: Helm
    olake.io/part-of: olake
spec:
  type:
  ports:
  - port: 8081
    targetPort: 8081
    protocol: TCP
    name: http
  selector:
    app.kubernetes.io/name: temporal-ui
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: workflow-ui
```