### PR TITLE
fix: set task queue

### DIFF
--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "0.1.0"
 home: https://github.com/datazip-inc/olake-helm
 sources:

--- a/helm/olake/templates/olake-ui/configmap.yaml
+++ b/helm/olake/templates/olake-ui/configmap.yaml
@@ -14,16 +14,13 @@ data:
   app.conf: |
     appname = olake-server
     httpport = {{ .Values.olakeUI.env.HTTP_PORT | default "8000" }}
-    runmode = {{ .Values.olakeUI.env.RUN_MODE | default .Values.global.env.RUN_MODE | default "dev" }}
+    runmode = {{ .Values.olakeUI.env.RUN_MODE | default .Values.global.env.RUN_MODE | default "staging" }}
     autorender = false
     copyrequestbody = true
     EnableDocs = true
     postgresdb = postgres://{{ .Values.postgresql.auth.postgresUser }}:{{ .Values.postgresql.auth.postgresPassword }}@postgresql.{{ include "olake.namespace" . }}.svc.cluster.local:5432/postgres?sslmode=disable
     logsdir = ./logger/logs
     sessionon = true
-    
-    # Deployment Mode
-    DEPLOYMENT_MODE = kubernetes
     
     # Temporal Configuration
     TEMPORAL_ADDRESS = temporal.{{ include "olake.namespace" . }}.svc.cluster.local:7233

--- a/helm/olake/templates/olake-ui/deployment.yaml
+++ b/helm/olake/templates/olake-ui/deployment.yaml
@@ -84,6 +84,8 @@ spec:
         {{- end }}
         volumeMounts:
         - name: olake-config
+          mountPath: /opt/backend/conf
+        - name: olake-config
           mountPath: /app/olake-ui/conf
         - name: shared-storage
           mountPath: /tmp/olake-config

--- a/helm/olake/templates/olake-worker/configmap.yaml
+++ b/helm/olake/templates/olake-worker/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   # Temporal Configuration
   TEMPORAL_ADDRESS: "temporal.{{ include "olake.namespace" . }}.svc.cluster.local:7233"
-  TEMPORAL_TASK_QUEUE: {{ .Values.olakeWorker.env.TEMPORAL_TASK_QUEUE | default "OLAKE_K8S_TASK_QUEUE" | quote }}
+  TEMPORAL_TASK_QUEUE: {{ .Values.olakeWorker.env.TEMPORAL_TASK_QUEUE | default "OLAKE_DOCKER_TASK_QUEUE" | quote }}
   
   # Database Configuration
   DB_HOST: "postgresql.{{ include "olake.namespace" . }}.svc.cluster.local"
@@ -39,7 +39,7 @@ data:
   LOG_FORMAT: {{ .Values.olakeWorker.config.logging.format | quote }}
   
   # Runtime Configuration
-  RUN_MODE: {{ .Values.olakeWorker.env.RUN_MODE | default .Values.global.env.RUN_MODE | default "staging" | quote }}
+  RUN_MODE: {{ .Values.olakeWorker.env.RUN_MODE | default .Values.global.env.RUN_MODE | default "staging" }}
   
   # =================================================================
   # JOB MAPPING CONFIGURATION

--- a/helm/olake/templates/olake-worker/configmap.yaml
+++ b/helm/olake/templates/olake-worker/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   # Temporal Configuration
   TEMPORAL_ADDRESS: "temporal.{{ include "olake.namespace" . }}.svc.cluster.local:7233"
-  TEMPORAL_TASK_QUEUE: {{ .Values.olakeWorker.env.TEMPORAL_TASK_QUEUE | default "OLAKE_DOCKER_TASK_QUEUE" | quote }}
+  TEMPORAL_TASK_QUEUE: {{ .Values.olakeWorker.env.TEMPORAL_TASK_QUEUE | default "OLAKE_DOCKER_TASK_QUEUE" }}
   
   # Database Configuration
   DB_HOST: "postgresql.{{ include "olake.namespace" . }}.svc.cluster.local"

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.1</p>
+                <p><strong>Version:</strong> 0.0.2</p>
                 <p><strong>App Version:</strong> 0.1.0</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">


### PR DESCRIPTION
This PR focuses on the following:
- Setting the Task Queue to OLAKE_DOCKER_TASK_QUEUE by default
- Mounting the `app.conf` to both `/opt/backend/conf` and `/app/olake-ui/conf/`
- Setting runMode to staging for both `k8s worker` and `olake-ui`