### PR TITLE
fix: handle workflow cancellation and external pod deletion

### DIFF
--- a/olake-workers/k8s/activities/activities.go
+++ b/olake-workers/k8s/activities/activities.go
@@ -199,8 +199,13 @@ func (a *Activities) SyncActivity(ctx context.Context, params shared.SyncParams)
 
 	// Note: Final state saving is now handled by SyncCleanupActivity in the workflow defer block
 	result, err := a.podManager.ExecutePodActivity(ctx, request)
-	if err != nil && errors.Is(err, pods.ErrPodFailed) {
-		return nil, temporal.NewNonRetryableApplicationError("sync connector failed", "PodFailed", err)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, temporal.NewCanceledError("sync cancelled")
+		}
+		if errors.Is(err, pods.ErrPodFailed) {
+			return nil, temporal.NewNonRetryableApplicationError("sync connector failed", "PodFailed", err)
+		}
 	}
 	return result, err
 }

--- a/olake-workers/k8s/pods/executor.go
+++ b/olake-workers/k8s/pods/executor.go
@@ -193,6 +193,9 @@ func (k *K8sPodManager) WaitForPodCompletion(ctx context.Context, podName string
 
 		pod, err := k.clientset.CoreV1().Pods(k.namespace).Get(ctx, podName, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("%w: pod %s was not found", ErrPodFailed, podName)
+			}
 			return nil, fmt.Errorf("failed to get pod status: %v", err)
 		}
 


### PR DESCRIPTION
- Convert context.Canceled to temporal.NewCanceledError in activity layer
- Detect external pod deletion and fail with ErrPodFailed
- Workflows now show as "Cancelled" instead of "Failed" when cancelled
- Prevent pod recreation when manually deleted during execution