### PR TITLE
feat: add liveness probe to activity pods for sync workflows

### DIFF
--- a/worker/executor/kubernetes/pod.go
+++ b/worker/executor/kubernetes/pod.go
@@ -221,7 +221,7 @@ func (k *KubernetesExecutor) CreatePodSpec(req *types.ExecutionRequest, workDir,
 	}
 
 	// Add liveness probe for long-running sync operations
-	if req.Command == types.Sync {
+	if slices.Contains(constants.AsyncCommands, req.Command) {
 		pod.Spec.Containers[0].LivenessProbe = &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{


### PR DESCRIPTION
# Description

Add healthcheck capability to sync job activity pods to detect and handle stuck or unresponsive containers. The probe writes to a shared volume that can be monitored for pod health status.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
