### PR TITLE
worker: staging to master (v0.2.5)

### DIFF
--- a/helm/olake/README.md
+++ b/helm/olake/README.md
@@ -133,24 +133,31 @@ With this powerful feature, specific data jobs can be routed to specific Kuberne
 ***Where is the JobID found?***
 The JobID is an integer that is automatically assigned to each job created in OLake UI. The JobID can be found in the corresponding row for each job on the Jobs page.
 
+**Default Node Selector:**
+You can define a **default node selector** using the special key `"0"`. This selector will be applied to:
+1. All unmapped Sync jobs (jobs without a specific ID mapping).
+2. All short-lived operations (Check Connection, Schema Discovery).
+
 ```yaml
 global:
   jobMapping:
-    123:
+    "0": # Default for all unmapped jobs & short-lived tasks
+      node-type: "standard"
+    123: # Specific mapping for Job 123
       olake.io/workload-type: "heavy"
     456:
       node-type: "high-cpu"
     789:
       olake.io/workload-type: "small"
-    999: {} # Empty mapping uses default scheduling
   
-  # - JobID Format: Must be positive integers (e.g., 123, 456, 789)
+  # - JobID Format: Must be positive integers or "0" for default
   # - Label Keys: Must follow RFC 1123 DNS subdomain format (lowercase letters, numbers, hyphens, dots)
   # - Label Values: Must be valid Kubernetes label values (63 chars max, alphanumeric with hyphens)
 ```
 
 **Note on Default Behavior:** 
-- For any JobID that is not specified in the jobMapping configuration, the corresponding job's pod will be scheduled by the standard Kubernetes scheduler, which places it on any available node in the cluster. 
+- If `"0"` (Default) is configured, it is used for all unmapped jobs and other activities (Fetch, Test, Discover).
+- If `"0"` is NOT configured, unmapped jobs are scheduled by the standard Kubernetes scheduler (on any available node), but with automatic anti-affinity rules to avoid nodes reserved for other mapped jobs. 
 
 ### Cloud IAM Integration
 

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -33,12 +33,15 @@ global:
   # -- JobID-based node mapping configuration for pods created by olake-workers
   # Maps JobID (integer) to specific node labels for pod scheduling
   # Format: { jobID: { node_label: node_value } }
+  # Special Key "0": Defines the DEFAULT node selector.
+  #   - Applied to all Sync jobs that don't have a specific JobID mapping.
+  #   - Applied to all short-lived jobs (test, discover, spec).
   # Example:
   #   jobMapping:
-  #     123:
+  #     "0":                 # Default selector
+  #       node-type: "standard"
+  #     123:                 # Specific job selector
   #       olake.io/workload-type: "heavy"
-  #     456:
-  #       node-type: "high-cpu"
   jobMapping: {}
 
   # -- Service account configuration for job pods created by olake-workers

--- a/worker/executor/kubernetes/helper.go
+++ b/worker/executor/kubernetes/helper.go
@@ -17,17 +17,23 @@ import (
 // Returns empty map if no mapping is found (graceful fallback)
 // Only applies node mapping for async operations (sync, clear destination)
 func (k *KubernetesExecutor) GetNodeSelectorForJob(jobID int, operation types.Command) map[string]string {
-	// Only apply node mapping for async operations
-	if !slices.Contains(constants.AsyncCommands, operation) {
-		return make(map[string]string)
+	// 1. Try specific mapping (Preferred)
+	// Only apply specific mapping for async operations (sync)
+	if slices.Contains(constants.AsyncCommands, operation) {
+		if mapping, exists := k.configWatcher.GetJobMapping(jobID); exists {
+			logger.Infof("found node mapping for JobID %d: %v", jobID, mapping)
+			return mapping
+		}
 	}
 
-	// Use live mapping from ConfigMapWatcher
-	if mapping, exists := k.configWatcher.GetJobMapping(jobID); exists {
-		logger.Infof("found node mapping for JobID %d: %v", jobID, mapping)
+	// 2. Try default mapping (JobID 0)
+	// Apply default mapping for ALL operations (sync, test, discover and spec)
+	if mapping, exists := k.configWatcher.GetJobMapping(0); exists {
+		logger.Debugf("using default node mapping: %v", mapping)
 		return mapping
 	}
-	logger.Debugf("no node mapping found for JobID %d, using default scheduling", jobID)
+
+	logger.Debugf("no specific or default mapping found for JobID %d, using standard scheduling", jobID)
 	return make(map[string]string)
 }
 
@@ -64,6 +70,13 @@ func (k *KubernetesExecutor) BuildAffinityForJob(jobID int, operation types.Comm
 	}
 
 	if _, exists := k.configWatcher.GetJobMapping(jobID); exists {
+		return nil
+	}
+
+	// If default mapping exists (JobID 0), trust it for placement.
+	// Do not auto-generate anti-affinity rules which might conflict with the default selector.
+	// Example: If Default=gpu and Job1=gpu, Anti-Affinity (NotIn gpu) would make unmapped jobs unschedulable on Default nodes.
+	if _, exists := k.configWatcher.GetJobMapping(0); exists {
 		return nil
 	}
 

--- a/worker/executor/kubernetes/scheduling.go
+++ b/worker/executor/kubernetes/scheduling.go
@@ -45,7 +45,7 @@ func validateLabelPair(jobID int, key, value string, stats *JobMappingStats) err
 
 // validateJobMapping validates a single job mapping entry
 func validateJobMapping(jobID int, nodeLabels map[string]string, stats *JobMappingStats) (map[string]string, bool) {
-	if jobID <= 0 {
+	if jobID < 0 {
 		stats.InvalidMappings = append(stats.InvalidMappings, fmt.Sprintf("Invalid JobID: %d", jobID))
 		return nil, false
 	}


### PR DESCRIPTION
# Release v0.2.5: Default Node Selector

## 🚀 New Features

### Default Node Selector (JobID "0")
Introduces support for a fallback node selector using the special JobID `"0"`. This allows administrators to define a default scheduling strategy for:
- Unmapped Sync Jobs (jobs without a specific ID mapping).
- Short-lived utility pods (Connection Checks, Schema Discovery).

**Configuration Example:**
```yaml
global:
  jobMapping:
    "0":
      node-type: "standard" # Default pool
    123:
      node-type: "heavy"    # Specific pool
```

**Behavior Changes:**
- **With Default ("0"):** Unmapped jobs schedule on the defined default nodes. Anti-affinity rules are disabled to allow resource sharing.
- **Without Default:** Unmapped jobs fall back to standard Kubernetes scheduling with automatic anti-affinity (avoiding nodes reserved for other mapped jobs).

## 🛠 Improvements
- **Logging:** Enhanced worker logs to clearly indicate when standard vs. default scheduling is applied.
- **Validation:** Updated validation logic to accept JobID `0` as a valid configuration key.

## 🧪 Testing
- Verified on AKS with multiple node pools.
- Tested scenarios: Specific Mapping Only, Default Mapping, and Infrastructure Failover.
- Verified backward compatibility with existing configurations.
