### PR TITLE
fix: Temp fixes in affinity

### DIFF
--- a/worker/executor/kubernetes/helper.go
+++ b/worker/executor/kubernetes/helper.go
@@ -14,46 +14,66 @@ import (
 
 // GetNodeSelectorForJob returns node selector configuration for the given jobID
 func (k *KubernetesExecutor) GetNodeSelectorForJob(jobID int, operation types.Command) map[string]string {
-	// 1. Try specific mapping (Preferred)
+	// 1. Default mapping (JobID 0) applies to all operations
+	var defaultSelector map[string]string
+	if config, exists := k.configWatcher.GetJobMapping(0); exists {
+		if config.NodeSelector != nil {
+			defaultSelector = config.NodeSelector
+		}
+	}
+
+	// 2. Job-specific mapping applies only to async operations (sync/clear-destination)
 	if slices.Contains(constants.AsyncCommands, operation) {
 		if config, exists := k.configWatcher.GetJobMapping(jobID); exists {
+			// NodeSelector nil => not specified => inherit default
 			if config.NodeSelector != nil {
 				logger.Infof("found node selector for JobID %d: %v", jobID, config.NodeSelector)
 				return config.NodeSelector
+			}
+			if defaultSelector != nil {
+				logger.Debugf("inheriting default node selector for JobID %d", jobID)
+				return defaultSelector
 			}
 			return map[string]string{}
 		}
 	}
 
-	// 2. Try default mapping (JobID 0)
-	if config, exists := k.configWatcher.GetJobMapping(0); exists {
-		if config.NodeSelector != nil {
-			logger.Debugf("using default node selector: %v", config.NodeSelector)
-			return config.NodeSelector
-		}
+	if defaultSelector != nil {
+		logger.Debugf("using default node selector for JobID %d: %v", jobID, defaultSelector)
+		return defaultSelector
 	}
 
-	logger.Debugf("no specific or default node selector for JobID %d", jobID)
+	logger.Debugf("no job-specific or default node selector for JobID %d", jobID)
 	return map[string]string{}
 }
 
 // GetTolerationsForJob returns tolerations for the given jobID
 func (k *KubernetesExecutor) GetTolerationsForJob(jobID int, operation types.Command) []corev1.Toleration {
-	// 1. Try specific mapping
+	// 1. Default tolerations (JobID 0) apply to all operations
+	var defaultTolerations []corev1.Toleration
+	if config, exists := k.configWatcher.GetJobMapping(0); exists {
+		// nil slice => not set; empty slice => explicitly set empty (clear)
+		if config.Tolerations != nil {
+			defaultTolerations = config.Tolerations
+		}
+	}
+
+	// 2. Job-specific tolerations apply only to async operations (sync/clear-destination)
 	if slices.Contains(constants.AsyncCommands, operation) {
 		if config, exists := k.configWatcher.GetJobMapping(jobID); exists {
-			if len(config.Tolerations) > 0 {
+			// nil slice => not specified => inherit default
+			if config.Tolerations != nil {
 				return config.Tolerations
+			}
+			if defaultTolerations != nil {
+				return defaultTolerations
 			}
 			return []corev1.Toleration{}
 		}
 	}
 
-	// 2. Try default mapping
-	if config, exists := k.configWatcher.GetJobMapping(0); exists {
-		if len(config.Tolerations) > 0 {
-			return config.Tolerations
-		}
+	if defaultTolerations != nil {
+		return defaultTolerations
 	}
 
 	return []corev1.Toleration{}
@@ -61,31 +81,90 @@ func (k *KubernetesExecutor) GetTolerationsForJob(jobID int, operation types.Com
 
 // BuildAffinityForJob returns affinity rules for the given jobID
 func (k *KubernetesExecutor) BuildAffinityForJob(jobID int, operation types.Command) *corev1.Affinity {
+	// 1. Explicit Config (Preferred)
+	// Preserve legacy behavior: only apply job-specific overrides for async commands (sync/clear-destination).
+	// Default (JobID 0) applies to all operations, including short-lived jobs.
+	if slices.Contains(constants.AsyncCommands, operation) {
+		if config, exists := k.configWatcher.GetJobMapping(jobID); exists {
+			if config.Affinity != nil {
+				logger.Infof("using explicit affinity for JobID %d", jobID)
+				return config.Affinity
+			}
+			// Affinity not specified => inherit default affinity (if any).
+			// Note: auto-generated rules (legacy safety-net) are still suppressed below when a job config exists.
+		}
+	}
+
+	// 2. Default Config (JobID 0) applies to all operations
+	if config, exists := k.configWatcher.GetJobMapping(0); exists {
+		if config.Affinity != nil {
+			logger.Debugf("using default affinity (JobID 0) for JobID %d", jobID)
+			return config.Affinity
+		}
+	}
+
+	// 3. Legacy safety-net (migration support):
+	// If there are other job mappings/profiles using NodeSelectors and this job is unmapped,
+	// generate a NotIn nodeAffinity so "unmapped" async jobs don't accidentally land on reserved nodes.
+	// This preserves behavior from the previous implementation when users only configured jobMapping without a default (0).
 	if !slices.Contains(constants.AsyncCommands, operation) {
 		return nil
 	}
 
-	// 1. Explicit Config (Preferred)
-	if config, exists := k.configWatcher.GetJobMapping(jobID); exists {
-		if config.Affinity != nil {
-			logger.Infof("using explicit affinity for JobID %d", jobID)
-			return config.Affinity
-		}
-		// If explicit profile exists (even without affinity), we DO NOT generate auto-rules.
-		// The user manages this job explicitly.
+	// If job-specific config exists but doesn't specify affinity, assume the user is managing scheduling
+	// and do not auto-generate rules.
+	if _, exists := k.configWatcher.GetJobMapping(jobID); exists {
 		return nil
 	}
 
-	// 2. Default Config (JobID 0)
-	if config, exists := k.configWatcher.GetJobMapping(0); exists {
-		if config.Affinity != nil {
-			logger.Debugf("using default affinity for JobID %d", jobID)
-			return config.Affinity
-		}
+	all := k.configWatcher.GetAllJobMapping()
+	if len(all) == 0 {
 		return nil
 	}
 
-	return nil
+	// Collect unique label values per key across all configured NodeSelectors.
+	uniq := map[string]map[string]struct{}{}
+	for _, cfg := range all {
+		for k, v := range cfg.NodeSelector {
+			if k == "" || v == "" {
+				continue
+			}
+			if _, ok := uniq[k]; !ok {
+				uniq[k] = map[string]struct{}{}
+			}
+			uniq[k][v] = struct{}{}
+		}
+	}
+
+	if len(uniq) == 0 {
+		return nil
+	}
+
+	expressions := make([]corev1.NodeSelectorRequirement, 0, len(uniq))
+	for labelKey, labelValues := range uniq {
+		values := make([]string, 0, len(labelValues))
+		for v := range labelValues {
+			values = append(values, v)
+		}
+		slices.Sort(values)
+
+		expressions = append(expressions, corev1.NodeSelectorRequirement{
+			Key:      labelKey,
+			Operator: corev1.NodeSelectorOpNotIn,
+			Values:   values,
+		})
+	}
+
+	logger.Debugf("using legacy auto anti-affinity for unmapped JobID %d (reserved label pairs: %d keys)", jobID, len(uniq))
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{MatchExpressions: expressions},
+				},
+			},
+		},
+	}
 }
 
 func (k *KubernetesExecutor) sanitizeName(name string) string {


### PR DESCRIPTION
Got it. I’ll review this PR like I would before merge: verify Helm → ConfigMap → worker parsing → pod spec wiring, check backward-compat behavior (legacy `jobMapping`), and then run `go test` in `worker/` to catch compile/runtime issues from the refactor.

[7 tools called]

Nice — the Go-side wiring is already end-to-end (ConfigMap watcher merges legacy + profiles, then pod spec reads nodeSelector/tolerations/affinity). Next I’m going to sanity-check a couple subtle migration behaviors: default profile semantics (especially affinity for non-async jobs), and the removed “auto anti-affinity” safety net from the old implementation, then I’ll run `go test` to catch any compile/runtime regressions.

[3 tools called]

Aha: there’s one concrete migration bug and one subtle behavior regression. Bug: `BuildAffinityForJob` currently *never applies default affinity* for non-async jobs, but `values.yaml` explicitly says the default profile (JobID `0`) should apply to short-lived jobs too. Regression: the old “auto anti-affinity for unmapped sync jobs” safety net is gone, which can change scheduling for existing `jobMapping` users who didn’t define a default (`0`) mapping. I’m going to patch both, then run `go test ./...` to confirm the worker builds cleanly.

[3 tools called]

Now that the migration semantics are fixed (default affinity applies to short-lived jobs; legacy “unmapped job” protection restored), the next step is to run `go test ./...` in `worker/` to ensure the refactor compiles and nothing else broke across packages.

[21 tools called]

### Key migration issues found (and fixed)

- **Profiles “override” would silently drop legacy nodeSelector**
  - In the PR diff, `jobProfiles[jobID]` replaced the entire legacy entry for the same JobID. If a user migrated by adding only `tolerations`/`affinity` in `jobProfiles`, they’d unexpectedly lose the legacy `nodeSelector` and also stop inheriting defaults.
  - Fixed by doing a **field-wise merge** (profiles override only fields they explicitly set; missing fields inherit from legacy) in `ConfigMapWatcher.updateJobMapping`.

```177:201:worker/executor/kubernetes/watcher.go
	// Merge/Overwrite with Profiles
	for jobID, config := range jobProfiles {
		if legacy, ok := finalConfig[jobID]; ok {
			// Field-wise merge for migration safety:
			// - If a profile omits a field, inherit it from legacy mapping.
			// - If a profile explicitly sets an empty object/array, it overrides (clears).
			merged := legacy

			if config.NodeSelector != nil {
				merged.NodeSelector = config.NodeSelector
			}
			// nil slice = not provided; empty slice = explicitly provided empty (clear)
			if config.Tolerations != nil {
				merged.Tolerations = config.Tolerations
			}
			if config.Affinity != nil {
				merged.Affinity = config.Affinity
			}

			finalConfig[jobID] = merged
			continue
		}

		finalConfig[jobID] = config
	}
```

- **Default profile (`0`) affinity was not applied to short-lived jobs**
  - `values.yaml` says JobID `0` is the default for short-lived operations too, but the new `BuildAffinityForJob` returned `nil` for non-async commands.
  - Fixed: default affinity (JobID `0`) is now applied for all operations.

- **Defaults were not inherited when a job-specific entry existed**
  - If a job had a profile entry but omitted `nodeSelector`/`tolerations`, the prior logic treated that as “configured” and returned empty values instead of inheriting JobID `0`.
  - Fixed by implementing **per-field inheritance** for nodeSelector/tolerations (and affinity) in `helper.go`.

```15:104:worker/executor/kubernetes/helper.go
func (k *KubernetesExecutor) GetNodeSelectorForJob(jobID int, operation types.Command) map[string]string {
	// 1. Default mapping (JobID 0) applies to all operations
	var defaultSelector map[string]string
	if config, exists := k.configWatcher.GetJobMapping(0); exists {
		if config.NodeSelector != nil {
			defaultSelector = config.NodeSelector
		}
	}

	// 2. Job-specific mapping applies only to async operations (sync/clear-destination)
	if slices.Contains(constants.AsyncCommands, operation) {
		if config, exists := k.configWatcher.GetJobMapping(jobID); exists {
			// NodeSelector nil => not specified => inherit default
			if config.NodeSelector != nil {
				return config.NodeSelector
			}
			if defaultSelector != nil {
				return defaultSelector
			}
			return map[string]string{}
		}
	}

	if defaultSelector != nil {
		return defaultSelector
	}
	return map[string]string{}
}
```

### Legacy behavior compatibility (important)

- **Old “unmapped sync jobs avoid reserved nodes” safety net regressed**
  - The previous implementation auto-generated a `NotIn` nodeAffinity for unmapped sync jobs when `jobMapping` existed but no default (`0`) mapping existed.
  - This behavior is important for existing users; I restored it as a fallback for **async commands only** (and only when there’s no default profile and no job-specific config), using merged mappings.

```106:167:worker/executor/kubernetes/helper.go
// 3. Legacy safety-net (migration support):
// ...
if !slices.Contains(constants.AsyncCommands, operation) {
	return nil
}
if _, exists := k.configWatcher.GetJobMapping(jobID); exists {
	return nil
}
all := k.configWatcher.GetAllJobMapping()
// ... build NotIn nodeAffinity from all NodeSelectors ...
```

### Helm/docs gaps

- **Helm ConfigMap wiring looks correct** (`OLAKE_JOB_MAPPING` + `OLAKE_JOB_PROFILES` both supported; worker merges them).
- **Chart README was outdated** (only documented `jobMapping`). I updated `helm/olake/README.md` to document `jobProfiles`, mark `jobMapping` deprecated, and describe safe migration.

### Validation / build status

- **`go test ./...` in `worker/` passes** after these fixes (compiles cleanly).

If you want, I can also add a tiny table in the README spelling out precedence/inheritance rules explicitly (default vs job-specific; and how to “clear” a default by setting empty `{}` / `[]`).