### PR TITLE
chore: staging -> master v0.0.8

### DIFF
--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.7
-appVersion: "0.2.3"
+version: 0.0.8
+appVersion: "0.2.5"
 home: https://github.com/datazip-inc/olake-helm
 sources:
   - https://github.com/datazip-inc/olake-helm

--- a/helm/olake/templates/olake-worker/configmap.yaml
+++ b/helm/olake/templates/olake-worker/configmap.yaml
@@ -10,25 +10,10 @@ metadata:
 data:
   # Temporal Configuration
   TEMPORAL_ADDRESS: "temporal.{{ include "olake.namespace" . }}.svc.cluster.local:7233"
-  TEMPORAL_TASK_QUEUE: {{ .Values.olakeWorker.env.TEMPORAL_TASK_QUEUE | default "OLAKE_DOCKER_TASK_QUEUE" }}
-  
-  # Timeout Configuration
-  TIMEOUT_ACTIVITY_DISCOVER: {{ .Values.olakeWorker.config.timeouts.activity.discover | quote }}
-  TIMEOUT_ACTIVITY_TEST: {{ .Values.olakeWorker.config.timeouts.activity.test | quote }}
-  TIMEOUT_ACTIVITY_SYNC: {{ .Values.olakeWorker.config.timeouts.activity.sync | quote }}
-  TIMEOUT_ACTIVITY_SPEC: {{ .Values.olakeWorker.config.timeouts.activity.spec | quote }}
   
   # Kubernetes Configuration
   WORKER_NAMESPACE: {{ include "olake.namespace" . | quote }}
-  IMAGE_REGISTRY: "olakego"
-  IMAGE_PULL_POLICY: "Always"
-  SERVICE_ACCOUNT: {{ include "olake.workerServiceAccountName" . | quote }}
   OLAKE_STORAGE_PVC_NAME: {{ include "olake.sharedStoragePVC" . | quote }}
-  
-  # Worker Configuration
-  MAX_CONCURRENT_ACTIVITIES: {{ .Values.olakeWorker.config.worker.maxConcurrentActivities | quote }}
-  MAX_CONCURRENT_WORKFLOWS: {{ .Values.olakeWorker.config.worker.maxConcurrentWorkflows | quote }}
-
 
   # Logging Configuration
   LOG_LEVEL: {{ .Values.olakeWorker.config.logging.level | quote }}
@@ -40,10 +25,18 @@ data:
   # API Callback
   OLAKE_CALLBACK_URL: "http://olake-ui.{{ include "olake.namespace" . }}.svc.cluster.local:8000/internal/worker/callback"
   # =================================================================
-  # JOB MAPPING CONFIGURATION
+  # JOB MAPPING CONFIGURATION (Deprecated)
   # =================================================================
   {{- if .Values.global.jobMapping }}
   OLAKE_JOB_MAPPING: {{ .Values.global.jobMapping | toJson | quote }}
+  {{- end }}
+
+  # =================================================================
+  # JOB PROFILES CONFIGURATION
+  # =================================================================
+  {{- if .Values.global.jobProfiles }}
+  # Converted to JSON for consistent parsing by the worker
+  OLAKE_JOB_PROFILES: {{ .Values.global.jobProfiles | toJson | quote }}
   {{- end }}
   
   # =================================================================

--- a/helm/olake/values.schema.json
+++ b/helm/olake/values.schema.json
@@ -8,7 +8,7 @@
       "properties": {
         "jobMapping": {
           "type": "object",
-          "description": "Mapping of JobIDs to node selectors for pod scheduling. Example: { \"123\": { \"node-type\": \"gpu\" }, \"456\": { \"instance-type\": \"memory-optimized\" } }",
+          "description": "[Deprecated] Mapping of JobIDs to node selectors for pod scheduling",
           "patternProperties": {
             "^[0-9]+$": {
               "type": "object",
@@ -38,6 +38,51 @@
               }
             }
           ]
+        },
+        "jobProfiles": {
+          "type": "object",
+          "description": "Advanced scheduling profiles for specific JobIDs. Allows defining nodeSelector, tolerations, and affinity.",
+          "patternProperties": {
+            "^[0-9]+$": {
+              "type": "object",
+              "properties": {
+                "nodeSelector": {
+                  "type": "object",
+                  "description": "Node labels for pod assignment.",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "tolerations": {
+                  "type": "array",
+                  "description": "List of tolerations.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "key": { "type": "string" },
+                      "operator": {
+                        "type": "string",
+                        "enum": ["Exists", "Equal"]
+                      },
+                      "value": { "type": "string" },
+                      "effect": {
+                        "type": "string",
+                        "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"]
+                      },
+                      "tolerationSeconds": { "type": "integer" }
+                    }
+                  }
+                },
+                "affinity": {
+                  "type": "object",
+                  "description": "Kubernetes affinity/anti-affinity rules.",
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
         }
       }
     }

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -30,19 +30,37 @@ global:
   #     - name: "docker-hub-secret"
   imagePullSecrets: []
 
-  # -- JobID-based node mapping configuration for pods created by olake-workers
-  # Maps JobID (integer) to specific node labels for pod scheduling
-  # Format: { jobID: { node_label: node_value } }
-  # Special Key "0": Defines the DEFAULT node selector.
-  #   - Applied to all Sync jobs that don't have a specific JobID mapping.
-  #   - Applied to all short-lived jobs (test, discover, spec).
-  # Example:
-  #   jobMapping:
-  #     "0":                 # Default selector
-  #       node-type: "standard"
-  #     123:                 # Specific job selector
-  #       olake.io/workload-type: "heavy"
+  # -- [DEPRECATED] JobID-based node mapping configuration
+  # Use `global.jobProfiles` instead. This field will be removed in a future release.
+  # Maps JobID (integer) to specific node labels for pod scheduling (NodeSelector only).
   jobMapping: {}
+
+  # -- JobID-based scheduling profiles for pods created by olake-workers
+  # Supports full Kubernetes scheduling capabilities (NodeSelector, Tolerations, Affinity).
+  # Overrides `jobMapping` if both are defined for the same JobID.
+  #
+  # Special Key "0": Defines the DEFAULT profile for all short-lived jobs (test, discover, spec)
+  # and any Sync jobs not mapped to a specific profile.
+  #
+  # Example:
+  #   jobProfiles:
+  #     0:    # Default Profile
+  #       nodeSelector:
+  #         node-type: "standard"
+  #       tolerations:
+  #         - key: "spot"
+  #           operator: "Exists"
+  #           effect: "NoSchedule"
+  #     123:                 # Specific Job Profile
+  #       affinity:
+  #         nodeAffinity:
+  #           requiredDuringSchedulingIgnoredDuringExecution:
+  #             nodeSelectorTerms:
+  #               - matchExpressions:
+  #                 - key: "gpu"
+  #                   operator: "In"
+  #                   values: ["true"]
+  jobProfiles: {}
 
   # -- Service account configuration for job pods created by olake-workers
   # Used for cloud provider IAM integration (AWS IRSA, GCP Workload Identity, Azure Workload Identity)
@@ -203,7 +221,7 @@ olakeUI:
 olakeWorker:
   # -- OLake Worker image configuration
   image:
-    repository: olakego/k8s-worker
+    repository: olakego/ui-worker
     tag: latest
     pullPolicy: Always
 
@@ -253,23 +271,6 @@ olakeWorker:
 
   # -- OLake Worker application configuration
   config:
-    worker:
-      # -- Maximum concurrent activities(https://docs.temporal.io/activities) per worker
-      # Increase for higher throughput, decrease for resource constraints
-      maxConcurrentActivities: 15
-
-      # -- Maximum concurrent workflows(https://docs.temporal.io/workflows) per worker
-      maxConcurrentWorkflows: 10
-
-    # -- Timeout configuration for different operation types
-    timeouts:
-      # -- Activity execution timeouts
-      activity:
-        discover: 2h
-        test: 2h
-        sync: 700h
-        spec: 5m
-
     # -- Logging configuration
     logging:
       level: info

--- a/worker/executor/kubernetes/helper.go
+++ b/worker/executor/kubernetes/helper.go
@@ -17,8 +17,26 @@ import (
 // Returns empty map if no mapping is found (graceful fallback)
 // Only applies node mapping for async operations (sync, clear destination)
 func (k *KubernetesExecutor) GetNodeSelectorForJob(jobID int, operation types.Command) map[string]string {
-	// 1. Try specific mapping (Preferred)
-	// Only apply specific mapping for async operations (sync)
+	// Check profiles for async operations
+	if slices.Contains(constants.AsyncCommands, operation) {
+		if profile, exists := k.configWatcher.GetJobProfile(jobID); exists {
+			if profile.NodeSelector != nil {
+				return profile.NodeSelector
+			}
+			return map[string]string{}
+		}
+	}
+
+	// Check default profile
+	if profile, exists := k.configWatcher.GetJobProfile(0); exists {
+		if profile.NodeSelector != nil {
+			return profile.NodeSelector
+		}
+		return map[string]string{}
+	}
+
+	// [TO BE DEPRECATED]
+	// Try specific mapping (Preferred)
 	if slices.Contains(constants.AsyncCommands, operation) {
 		if mapping, exists := k.configWatcher.GetJobMapping(jobID); exists {
 			logger.Infof("found node mapping for JobID %d: %v", jobID, mapping)
@@ -26,8 +44,8 @@ func (k *KubernetesExecutor) GetNodeSelectorForJob(jobID int, operation types.Co
 		}
 	}
 
-	// 2. Try default mapping (JobID 0)
-	// Apply default mapping for ALL operations (sync, test, discover and spec)
+	// [TO BE DEPRECATED]
+	// Try default mapping (JobID 0)
 	if mapping, exists := k.configWatcher.GetJobMapping(0); exists {
 		logger.Debugf("using default node mapping: %v", mapping)
 		return mapping
@@ -35,6 +53,31 @@ func (k *KubernetesExecutor) GetNodeSelectorForJob(jobID int, operation types.Co
 
 	logger.Debugf("no specific or default mapping found for JobID %d, using standard scheduling", jobID)
 	return make(map[string]string)
+}
+
+// GetTolerationsForJob returns tolerations for the given jobID
+func (k *KubernetesExecutor) GetTolerationsForJob(jobID int, operation types.Command) []corev1.Toleration {
+	// 1. Check specific profile
+	if slices.Contains(constants.AsyncCommands, operation) {
+		if profile, exists := k.configWatcher.GetJobProfile(jobID); exists {
+			if len(profile.Tolerations) > 0 {
+				return profile.Tolerations
+			}
+			return []corev1.Toleration{}
+		}
+	}
+
+	// 2. Check default profile
+	if profile, exists := k.configWatcher.GetJobProfile(0); exists {
+		if len(profile.Tolerations) > 0 {
+			logger.Debugf("using default profile tolerations")
+			return profile.Tolerations
+		}
+		logger.Debugf("default profile exists but tolerations empty")
+		return []corev1.Toleration{}
+	}
+
+	return []corev1.Toleration{}
 }
 
 func (k *KubernetesExecutor) sanitizeName(name string) string {
@@ -65,18 +108,38 @@ func (k *KubernetesExecutor) parseQuantity(s string) resource.Quantity {
 // Uses NotIn operator to exclude nodes with label key-value pairs used by any mapped job.
 // Reference: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
 func (k *KubernetesExecutor) BuildAffinityForJob(jobID int, operation types.Command) *corev1.Affinity {
-	if !slices.Contains(constants.AsyncCommands, operation) {
+	// Check if profile has explicit affinity
+	if profile, exists := k.configWatcher.GetJobProfile(jobID); exists {
+		if profile.Affinity != nil {
+			return profile.Affinity
+		}
 		return nil
 	}
 
+	// Check default profile
+	if profile, exists := k.configWatcher.GetJobProfile(0); exists {
+		if profile.Affinity != nil {
+			return profile.Affinity
+		}
+		return nil
+	}
+
+	// Check if job has explicit mapping
 	if _, exists := k.configWatcher.GetJobMapping(jobID); exists {
 		return nil
 	}
 
+	// [TO BE DEPRECATED]
 	// If default mapping exists (JobID 0), trust it for placement.
 	// Do not auto-generate anti-affinity rules which might conflict with the default selector.
 	// Example: If Default=gpu and Job1=gpu, Anti-Affinity (NotIn gpu) would make unmapped jobs unschedulable on Default nodes.
 	if _, exists := k.configWatcher.GetJobMapping(0); exists {
+		return nil
+	}
+
+	// For non-async operations, don't auto-generate anti-affinity
+	// They should only use explicit configs (profiles or mappings)
+	if !slices.Contains(constants.AsyncCommands, operation) {
 		return nil
 	}
 

--- a/worker/executor/kubernetes/pod.go
+++ b/worker/executor/kubernetes/pod.go
@@ -166,7 +166,7 @@ func (k *KubernetesExecutor) CreatePodSpec(req *types.ExecutionRequest, workDir,
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
 			NodeSelector:  k.GetNodeSelectorForJob(req.JobID, req.Command),
-			Tolerations:   []corev1.Toleration{},
+			Tolerations:   k.GetTolerationsForJob(req.JobID, req.Command),
 			Affinity:      k.BuildAffinityForJob(req.JobID, req.Command),
 			Containers: []corev1.Container{
 				{

--- a/worker/executor/kubernetes/watcher.go
+++ b/worker/executor/kubernetes/watcher.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/datazip-inc/olake-helm/worker/utils"
 	"github.com/datazip-inc/olake-helm/worker/utils/logger"
 )
 
@@ -24,8 +23,9 @@ type ConfigMapWatcher struct {
 	configMapName   string
 
 	// Thread-safe job mapping storage
-	mu         sync.RWMutex
-	jobMapping map[int]map[string]string // TODO: use sync.Map
+	mu          sync.RWMutex
+	jobMapping  map[int]map[string]string // TODO: use sync.Map
+	jobProfiles map[int]JobSchedulingConfig
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -38,6 +38,7 @@ func NewConfigMapWatcher(ctx context.Context, clientset kubernetes.Interface, na
 		namespace:     namespace,
 		configMapName: "olake-workers-config",
 		jobMapping:    make(map[int]map[string]string),
+		jobProfiles:   make(map[int]JobSchedulingConfig),
 		ctx:           ctx,
 		cancel:        cancel,
 	}
@@ -124,6 +125,15 @@ func (w *ConfigMapWatcher) GetJobMapping(jobID int) (map[string]string, bool) {
 	return result, true
 }
 
+// GetJobProfile returns profile for specific jobID (thread-safe)
+func (w *ConfigMapWatcher) GetJobProfile(jobID int) (JobSchedulingConfig, bool) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	profile, exists := w.jobProfiles[jobID]
+	return profile, exists
+}
+
 // GetAllJobMapping returns all job mappings (thread-safe)
 // Returns a deep copy to prevent external modification of internal state
 func (w *ConfigMapWatcher) GetAllJobMapping() map[int]map[string]string {
@@ -142,25 +152,25 @@ func (w *ConfigMapWatcher) GetAllJobMapping() map[int]map[string]string {
 }
 
 func (w *ConfigMapWatcher) updateJobMapping(cm *corev1.ConfigMap) {
-	rawMapping, exists := cm.Data["OLAKE_JOB_MAPPING"]
-	if !exists || rawMapping == "" {
-		log := utils.Ternary(!exists, "no OLAKE_JOB_MAPPING in ConfigMap %s", "mmpty OLAKE_JOB_MAPPING in ConfigMap %s").(string)
-		logger.Debugf(log, w.configMapName)
-		w.mu.Lock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	// [TO BE DEPRECATED]
+	// 1. Load legacy job mapping
+	if rawMapping, exists := cm.Data["OLAKE_JOB_MAPPING"]; exists && rawMapping != "" {
+		w.jobMapping = LoadJobMapping(rawMapping)
+		logger.Infof("updated job mapping with %d entries", len(w.jobMapping))
+	} else {
+		logger.Debugf("no OLAKE_JOB_MAPPING in ConfigMap %s", w.configMapName)
 		w.jobMapping = map[int]map[string]string{}
-		w.mu.Unlock()
-		return
 	}
 
-	newMapping := LoadJobMapping(rawMapping)
-
-	// Update thread-safe storage with exclusive lock
-	// Multiple Temporal activity goroutines call GetJobMapping() concurrently (readers)
-	// while this ConfigMap informer goroutine updates jobMapping (writer).
-	// RWMutex prevents data races and map corruption during concurrent access.
-	w.mu.Lock()
-	w.jobMapping = newMapping
-	w.mu.Unlock()
-
-	logger.Infof("updated job mapping with %d entries", len(newMapping))
+	// 2. Load job profiles
+	if rawProfiles, exists := cm.Data["OLAKE_JOB_PROFILES"]; exists && rawProfiles != "" {
+		w.jobProfiles = LoadJobProfiles(rawProfiles)
+		logger.Infof("updated job profiles with %d entries", len(w.jobProfiles))
+	} else {
+		logger.Debugf("no OLAKE_JOB_PROFILES in ConfigMap %s", w.configMapName)
+		w.jobProfiles = map[int]JobSchedulingConfig{}
+	}
 }


### PR DESCRIPTION
Feature: implement advanced job scheduling with profiles

Introduces a new flexible scheduling system for worker jobs, allowing full control over NodeSelector, Tolerations, and Affinity via a new `jobProfiles` configuration.

**Key Changes:**
- **Helm Interface:** Added `global.jobProfiles` to `values.yaml` which accepts full Kubernetes scheduling specs (Tolerations, Affinity, NodeSelector).
- **Architecture:** Implemented "YAML-to-JSON" injection strategy in ConfigMap to simplify backend parsing.
- **Worker Logic:**
  - Added `LoadJobProfiles` to parse the new JSON configuration.
  - Updated `ConfigMapWatcher` to merge legacy `jobMapping` with new `jobProfiles` (profiles take precedence).
  - Updated `CreatePodSpec` to apply the full scheduling context to new pods.
- **Cleanup:**
  - Removed legacy "Auto-Anti-Affinity" logic for unmapped jobs to reduce magic/implicit behavior.
  - Removed unused validation logic in favor of relying on Kubernetes API server validation.
  - Cleaned up unused helper functions and imports.
- **Technical Debt:** Added TODOs to track the eventual removal of the deprecated `jobMapping` feature.

**Configuration:**
Users can now define:
```yaml
global:
  jobProfiles:
    123:
      nodeSelector: { "disk": "ssd" }
      tolerations: [{ "key": "gpu", "operator": "Exists" }]
      affinity: { ... }
```

* fix(worker): enforce atomic override for job profiles

Fixed a bug where a job profile defining only `nodeSelector` would incorrectly inherit `tolerations` from the default profile (Job 0).

**Changes:**
- Updated `GetNodeSelectorForJob` and `GetTolerationsForJob` to prevent fallback to default settings if a specific job profile exists.
- Ensured that explicit profiles are authoritative: if a field is missing in the specific profile, it remains empty for that job.

* chore: remove unnecessary comments

* chore: modify worker image to ui-worker

* chore: bump up chart version

* feat: add validation for job profiles in values.schema.json

* chore: update description

* fix: default profile (0) affinity was not applied to short-lived jobs

* doc: update project structure and remove unnecessary ENV variables

* doc: update jobProfiles section

* chore: unnecessary comment remove

* chore: revert to master

* feat: add strict backward compatibility

* chore: remove debug logging

* chore: update default scheduling behaviour