### PR TITLE
feat: create postgres secret from values

### DIFF
--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.8
-appVersion: "0.2.5"
+version: 0.0.9
+appVersion: "0.2.8"
 home: https://github.com/datazip-inc/olake-helm
 sources:
   - https://github.com/datazip-inc/olake-helm

--- a/helm/olake/templates/_helpers.tpl
+++ b/helm/olake/templates/_helpers.tpl
@@ -95,7 +95,9 @@ Return the PostgreSQL secret name
 {{- define "olake.postgresql.secretName" -}}
 {{- if .Values.postgresql.enabled }}
 {{- printf "%s-postgresql-secret" (include "olake.fullname" .) }}
-{{- else }}
+{{- else if .Values.postgresql.external.existingSecret }}
 {{- .Values.postgresql.external.existingSecret }}
+{{- else }}
+{{- printf "%s-external-postgresql" (include "olake.fullname" .) }}
 {{- end }}
 {{- end }}

--- a/helm/olake/templates/external-postgresql-secret.yaml
+++ b/helm/olake/templates/external-postgresql-secret.yaml
@@ -1,0 +1,20 @@
+{{- if and (not .Values.postgresql.enabled) (not .Values.postgresql.external.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "olake.postgresql.secretName" . }}
+  namespace: {{ include "olake.namespace" . }}
+  labels:
+    {{- include "olake.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- with .Values.postgresql.external.properties }}
+  {{ $.Values.postgresql.external.secretKeys.host | default "host" }}: {{ .host | quote }}
+  {{ $.Values.postgresql.external.secretKeys.port | default "port" }}: {{ .port | quote }}
+  {{ $.Values.postgresql.external.secretKeys.username | default "username" }}: {{ .username | quote }}
+  {{ $.Values.postgresql.external.secretKeys.password | default "password" }}: {{ .password | quote }}
+  {{ $.Values.postgresql.external.secretKeys.olake_database | default "olake_database" }}: {{ .olake_database | quote }}
+  {{ $.Values.postgresql.external.secretKeys.temporal_database | default "temporal_database" }}: {{ .temporal_database | quote }}
+  {{ $.Values.postgresql.external.secretKeys.ssl_mode | default "ssl_mode" }}: {{ .ssl_mode | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/olake/templates/temporal/deployment.yaml
+++ b/helm/olake/templates/temporal/deployment.yaml
@@ -113,11 +113,15 @@ spec:
           {{- end }}
         {{- $sslConfig := dict "mode" "disable" }}
         {{- if not .Values.postgresql.enabled }}
-          {{- with lookup "v1" "Secret" .Release.Namespace .Values.postgresql.external.existingSecret }}
-            {{- $key := $.Values.postgresql.external.secretKeys.ssl_mode }}
-            {{- if and .data (hasKey .data $key) }}
-              {{- $_ := set $sslConfig "mode" (index .data $key | b64dec) }}
+          {{- if .Values.postgresql.external.existingSecret }}
+            {{- with lookup "v1" "Secret" .Release.Namespace .Values.postgresql.external.existingSecret }}
+              {{- $key := $.Values.postgresql.external.secretKeys.ssl_mode }}
+              {{- if and .data (hasKey .data $key) }}
+                {{- $_ := set $sslConfig "mode" (index .data $key | b64dec) }}
+              {{- end }}
             {{- end }}
+          {{- else }}
+            {{- $_ := set $sslConfig "mode" .Values.postgresql.external.properties.ssl_mode }}
           {{- end }}
         {{- end }}
         {{- if ne $sslConfig.mode "disable" }}

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -400,6 +400,16 @@ postgresql:
     #     --from-literal=ssl_mode=disable
     existingSecret: ""
 
+    # -- Explicit PostgreSQL properties (used if existingSecret is not set)
+    properties:
+      host: ""
+      port: 5432
+      username: ""
+      password: ""
+      olake_database: ""
+      temporal_database: ""
+      ssl_mode: "disable"
+
     # -- Map the keys from existing secret to the required fields
     secretKeys:
       host: "host"

--- a/index.html
+++ b/index.html
@@ -127,8 +127,8 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.7</p>
-                <p><strong>App Version:</strong> 0.2.3</p>
+                <p><strong>Version:</strong> 0.0.9</p>
+                <p><strong>App Version:</strong> 0.2.8</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">
                     <a href="https://github.com/datazip-inc/olake-helm/tree/master/helm/olake/README.md" target="_blank">📚 Documentation</a> |


### PR DESCRIPTION
NA (Stag merge)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how external PostgreSQL credentials are sourced and introduces a new Secret resource; misconfiguration could break Temporal/OLake DB connectivity or alter TLS behavior in GitOps installs.
> 
> **Overview**
> Adds a second external PostgreSQL configuration path: if `postgresql.enabled: false` and no `external.existingSecret` is provided, the chart now creates an `Opaque` Secret from `postgresql.external.properties` (GitOps/ArgoCD-friendly) and uses it via the updated `olake.postgresql.secretName` helper.
> 
> Updates Temporal’s TLS mode selection to use Helm `lookup` only when `existingSecret` is set, otherwise pulling `ssl_mode` from `external.properties`. Documentation and defaults are updated accordingly, and the chart/app versions are bumped (`0.0.9` / `0.2.8`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34e623dce61f2bd0cc9a272d8e1e67df55d5fcf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->