### PR TITLE
fix: fail worker startup if setting retention period fails

### DIFF
--- a/worker/main.go
+++ b/worker/main.go
@@ -59,8 +59,9 @@ func main() {
 	defer tClient.Close()
 
 	// Set namespace retention for workflow history visibility (default: 7 days).
+	// TODO: add healthcheck for temporal worker service in docker compose
 	if err := tClient.SetWorkflowRetentionPeriod(ctx); err != nil {
-		logger.Warnf("failed to update namespace retention: %s", err)
+		logger.Fatalf("failed to update namespace retention: %s", err)
 	}
 
 	worker, err := temporal.NewWorker(ctx, tClient, exec, db)

--- a/worker/temporal/client.go
+++ b/worker/temporal/client.go
@@ -58,7 +58,7 @@ func (t *Temporal) GetClient() client.Client {
 // SetWorkflowRetentionPeriod sets the workflow execution retention period for the default namespace.
 // This ensures workflow history is available for debugging (defaults to 7 days).
 // Handles both fresh installs and upgrades from shorter retention periods.
-// Non-fatal: worker continues with default retention period of 1 day if this fails.
+// Fatal: worker fails to start if this fails.
 func (t *Temporal) SetWorkflowRetentionPeriod(ctx context.Context) error {
 	retentionPeriod, err := time.ParseDuration(viper.GetString(constants.EnvTemporalRetentionPeriod))
 	if err != nil {


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR ensures that worker startup fails if unable to set temporal namespace retention period.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested with invalid configuration to make sure that worker startup fails.

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
