### PR TITLE
fix(chart): skip registry prefix for fully-qualified image URLs

### DIFF
--- a/helm/olake/templates/_helpers.tpl
+++ b/helm/olake/templates/_helpers.tpl
@@ -98,6 +98,29 @@ Uses CONTAINER_REGISTRY_BASE from global.env if set, otherwise defaults to regis
 {{- end -}}
 
 {{/*
+Build a full container image reference.
+If the repository already contains a registry (first path segment has a dot),
+the registryBase prefix is skipped. Otherwise the global registry base is prepended.
+This allows users to specify fully-qualified image URLs (e.g. ECR, GCR, GHCR)
+while still supporting the offline/air-gapped CONTAINER_REGISTRY_BASE workflow
+for Docker Hub images.
+
+Usage:
+  {{ include "olake.imageRef" (dict "repository" .Values.olakeUI.image.repository "tag" .Values.olakeUI.image.tag "context" .) }}
+*/}}
+{{- define "olake.imageRef" -}}
+{{- $repo := .repository -}}
+{{- $tag := .tag -}}
+{{- $parts := splitList "/" $repo -}}
+{{- $firstSegment := index $parts 0 -}}
+{{- if contains "." $firstSegment -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- else -}}
+{{- printf "%s/%s:%s" (include "olake.registryBase" .context) $repo $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the PostgreSQL secret name
 */}}
 {{- define "olake.postgresql.secretName" -}}

--- a/helm/olake/templates/elasticsearch/deployment.yaml
+++ b/helm/olake/templates/elasticsearch/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       containers:
       - name: elasticsearch
-        image: "{{ include "olake.registryBase" . }}/{{ .Values.elasticsearch.image.repository }}:{{ .Values.elasticsearch.image.tag }}"
+        image: "{{ include "olake.imageRef" (dict "repository" .Values.elasticsearch.image.repository "tag" .Values.elasticsearch.image.tag "context" .) }}"
         imagePullPolicy: {{ .Values.elasticsearch.image.pullPolicy }}
         ports:
         - name: http

--- a/helm/olake/templates/olake-ui/deployment.yaml
+++ b/helm/olake/templates/olake-ui/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           echo "Temporal is ready!"
       containers:
       - name: olake-ui
-        image: "{{ include "olake.registryBase" . }}/{{ .Values.olakeUI.image.repository }}:{{ .Values.olakeUI.image.tag }}"
+        image: "{{ include "olake.imageRef" (dict "repository" .Values.olakeUI.image.repository "tag" .Values.olakeUI.image.tag "context" .) }}"
         imagePullPolicy: {{ .Values.olakeUI.image.pullPolicy }}
         ports:
         - name: olake-ui

--- a/helm/olake/templates/olake-worker/deployment.yaml
+++ b/helm/olake/templates/olake-worker/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           echo "Temporal is ready!"
       containers:
       - name: olake-workers
-        image: "{{ include "olake.registryBase" . }}/{{ .Values.olakeWorker.image.repository }}:{{ .Values.olakeWorker.image.tag }}"
+        image: "{{ include "olake.imageRef" (dict "repository" .Values.olakeWorker.image.repository "tag" .Values.olakeWorker.image.tag "context" .) }}"
         imagePullPolicy: {{ .Values.olakeWorker.image.pullPolicy }}
         ports:
         - name: health

--- a/helm/olake/templates/postgresql/deployment.yaml
+++ b/helm/olake/templates/postgresql/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       containers:
       - name: postgresql
-        image: "{{ include "olake.registryBase" . }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+        image: "{{ include "olake.imageRef" (dict "repository" .Values.postgresql.image.repository "tag" .Values.postgresql.image.tag "context" .) }}"
         imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
         ports:
         - name: postgres

--- a/helm/olake/templates/temporal/deployment.yaml
+++ b/helm/olake/templates/temporal/deployment.yaml
@@ -77,7 +77,7 @@ spec:
               key: {{ if .Values.postgresql.enabled }}port{{ else }}{{ .Values.postgresql.external.secretKeys.port }}{{ end }}
       containers:
       - name: temporal
-        image: "{{ include "olake.registryBase" . }}/{{ .Values.temporal.server.image.repository }}:{{ .Values.temporal.server.image.tag }}"
+        image: "{{ include "olake.imageRef" (dict "repository" .Values.temporal.server.image.repository "tag" .Values.temporal.server.image.tag "context" .) }}"
         imagePullPolicy: {{ .Values.temporal.server.image.pullPolicy }}
         ports:
         - name: grpc


### PR DESCRIPTION
# Description

When using non-Docker-Hub registries (e.g. AWS ECR, GCR, GHCR) for OLake component images, the chart produces invalid image references because `registryBase` is unconditionally prepended to all image repositories.

For example, setting `olakeUI.image.repository: 123456789012.dkr.ecr.eu-west-1.amazonaws.com/olake-ui` produces:
```
registry-1.docker.io/123456789012.dkr.ecr.eu-west-1.amazonaws.com/olake-ui:v0.3.2
```

This causes `ErrImagePull` on all pods since the combined URL is not a valid registry path.

**Root cause:** The `olake.registryBase` helper (defaulting to `registry-1.docker.io`) is always prepended to user-configurable image repositories in templates, with no way to opt out for already-qualified URLs.

**Fix:** Add an `olake.imageRef` helper that checks if the repository is already fully-qualified (first path segment contains a `.`, e.g. `123456789012.dkr.ecr.eu-west-1.amazonaws.com/...`). If so, the registry prefix is skipped. Otherwise, `registryBase` is prepended as before.

This preserves full backwards compatibility:
- Default Docker Hub images (`olakego/ui`, `temporalio/auto-setup`, etc.) still get the prefix
- The `CONTAINER_REGISTRY_BASE` air-gapped/offline workflow continues to work
- Hardcoded utility images (`library/busybox`, `curlimages/curl`) are unchanged

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Verified with `helm template` across three scenarios:

- [x] **Default values** — Docker Hub images get `registry-1.docker.io/` prefix as before
- [x] **ECR repositories** — fully-qualified URLs like `123456789012.dkr.ecr.eu-west-1.amazonaws.com/olake-ui:v0.3.2` render without prefix
- [x] **Air-gapped override** — `CONTAINER_REGISTRY_BASE: my-private-registry.example.com` correctly prefixes all Docker Hub images
- [x] **Production deployment** — verified in a live Kubernetes cluster (previously worked around with a post-renderer that strips the prefix)

# Screenshots or Recordings

**Before (broken):**
```
image: "registry-1.docker.io/123456789012.dkr.ecr.eu-west-1.amazonaws.com/olake-ui:v0.3.2"
```

**After (fixed):**
```
image: "123456789012.dkr.ecr.eu-west-1.amazonaws.com/olake-ui:v0.3.2"
```

## Related PR's (If Any):
N/A