### PR TITLE
feat: configurable resources for worker-spawned connector pods

### DIFF
--- a/helm/olake/templates/olake-worker/configmap.yaml
+++ b/helm/olake/templates/olake-worker/configmap.yaml
@@ -51,3 +51,14 @@ data:
   {{- if .Values.olakeWorker.securityContext }}
   POD_SECURITY_CONTEXT: {{ .Values.olakeWorker.securityContext | toJson | quote }}
   {{- end }}
+
+  # =================================================================
+  # JOB POD RESOURCES CONFIGURATION
+  # =================================================================
+  # Resource requirements applied to short-lived connector pods (sync, discover, check)
+  # spawned by the worker. Accepts a standard Kubernetes ResourceRequirements block
+  # with `requests` and/or `limits`. Falls back to requests cpu=100m, memory=256Mi
+  # (no limits) when unset.
+  {{- if .Values.olakeWorker.jobPodResources }}
+  JOB_POD_RESOURCES: {{ .Values.olakeWorker.jobPodResources | toJson | quote }}
+  {{- end }}

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -262,6 +262,21 @@ olakeWorker:
   #       cpu: "1000m"
   resources: {}
 
+  # -- Resource requirements for short-lived connector pods (sync, discover, check)
+  # spawned by the worker via the Kubernetes API. These are SEPARATE from the worker
+  # deployment's own `resources` above.
+  # Accepts a standard Kubernetes ResourceRequirements block.
+  # Defaults (when unset): requests cpu=100m, memory=256Mi, no limits.
+  # Example:
+  #   jobPodResources:
+  #     requests:
+  #       cpu: "500m"
+  #       memory: "1Gi"
+  #     limits:
+  #       cpu: "2"
+  #       memory: "4Gi"
+  jobPodResources: {}
+
   # -- Olake Worker security context
   # Example customizations:
   # securityContext:

--- a/worker/constants/env.go
+++ b/worker/constants/env.go
@@ -45,4 +45,7 @@ const (
 
 	// security context
 	EnvPodSecurityContext = "POD_SECURITY_CONTEXT"
+
+	// job pod resources (JSON-encoded corev1.ResourceRequirements)
+	EnvJobPodResources = "JOB_POD_RESOURCES"
 )

--- a/worker/executor/kubernetes/executor.go
+++ b/worker/executor/kubernetes/executor.go
@@ -38,6 +38,7 @@ type KubernetesConfig struct {
 	BasePath          string
 	WorkerIdentity    string
 	SecurityContext   *corev1.PodSecurityContext
+	JobPodResources   *corev1.ResourceRequirements
 }
 
 func NewKubernetesExecutor(ctx context.Context) (*KubernetesExecutor, error) {
@@ -78,6 +79,17 @@ func NewKubernetesExecutor(ctx context.Context) (*KubernetesExecutor, error) {
 		}
 	}
 
+	// Parse job pod resources JSON if available
+	var jobPodResources *corev1.ResourceRequirements
+	jobPodResourcesJSON := viper.GetString(constants.EnvJobPodResources)
+	if jobPodResourcesJSON != "" {
+		jobPodResources = &corev1.ResourceRequirements{}
+		if err := json.Unmarshal([]byte(jobPodResourcesJSON), jobPodResources); err != nil {
+			logger.Errorf("failed to unmarshal job pod resources: %s. using default.", err)
+			jobPodResources = nil // Reset to nil on error
+		}
+	}
+
 	// Set worker identity
 	podName := viper.GetString(constants.EnvPodName)
 	workerIdenttity := fmt.Sprintf("olake.io/olake-workers/%s", podName)
@@ -100,6 +112,7 @@ func NewKubernetesExecutor(ctx context.Context) (*KubernetesExecutor, error) {
 			BasePath:          basePath,
 			WorkerIdentity:    workerIdenttity,
 			SecurityContext:   securityContext,
+			JobPodResources:   jobPodResources,
 		},
 	}, nil
 }

--- a/worker/executor/kubernetes/pod.go
+++ b/worker/executor/kubernetes/pod.go
@@ -131,6 +131,21 @@ func (k *KubernetesExecutor) cleanupPod(ctx context.Context, podName string) err
 	return nil
 }
 
+// buildJobPodResources returns the ResourceRequirements for connector pods.
+// Operators can override via olakeWorker.jobPodResources (helm) -> JOB_POD_RESOURCES env (JSON).
+// When unset, falls back to the historical defaults: requests cpu=100m, memory=256Mi, no limits.
+func (k *KubernetesExecutor) buildJobPodResources() corev1.ResourceRequirements {
+	if k.config.JobPodResources != nil {
+		return *k.config.JobPodResources
+	}
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceMemory: k.parseQuantity("256Mi"),
+			corev1.ResourceCPU:    k.parseQuantity("100m"),
+		},
+	}
+}
+
 func (k *KubernetesExecutor) CreatePodSpec(req *types.ExecutionRequest, workDir, imageName string) *corev1.Pod {
 	subDir := filepath.Base(workDir)
 
@@ -182,13 +197,7 @@ func (k *KubernetesExecutor) CreatePodSpec(req *types.ExecutionRequest, workDir,
 							SubPath:   subDir,
 						},
 					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceMemory: k.parseQuantity("256Mi"),
-							corev1.ResourceCPU:    k.parseQuantity("100m"),
-						},
-						// No limits for flexibility
-					},
+					Resources: k.buildJobPodResources(),
 					Env: []corev1.EnvVar{
 						{
 							Name:  "OLAKE_WORKFLOW_ID",


### PR DESCRIPTION
## Description

Adds `olakeWorker.jobPodResources` so operators can set CPU/memory **requests AND limits** on the short-lived sync/discover/check pods that the worker creates via the Kubernetes API.

Until now those values were hardcoded in `worker/executor/kubernetes/pod.go` to `requests: { cpu: 100m, memory: 256Mi }` with no limits, which makes sync runs prone to OOM/CPU contention with no operator escape hatch short of forking the chart or adding a mutating admission webhook.

Fixes [datazip-inc/olake#935](https://github.com/datazip-inc/olake/issues/935) (and [datazip-inc/olake-helm#120](https://github.com/datazip-inc/olake-helm/issues/120) which was closed without a merged fix).

## Design

The new value accepts a **standard Kubernetes `ResourceRequirements` block** — the same shape users already know from every other Helm chart and from `kubectl explain pod.spec.containers.resources`:

```yaml
olakeWorker:
  jobPodResources:
    requests:
      cpu: "500m"
      memory: "1Gi"
    limits:
      cpu: "2"
      memory: "4Gi"
```

It's plumbed through as a JSON-encoded `JOB_POD_RESOURCES` entry on the workers configmap, mirroring how `POD_SECURITY_CONTEXT` is already passed (see `helm/olake/templates/olake-worker/configmap.yaml`). The worker decodes it via `json.Unmarshal` into `*corev1.ResourceRequirements`.

### Backward compatibility

When `jobPodResources` is unset (or empty), no `JOB_POD_RESOURCES` key is emitted, the worker's `JobPodResources` field stays `nil`, and `buildJobPodResources()` returns the same `requests: { cpu: 100m, memory: 256Mi }` it always did. **Existing deployments are unaffected.**

### Why this shape over PR #121

[PR #121](https://github.com/datazip-inc/olake-helm/pull/121) (closed unmerged) used flat `cpu`/`memory` string fields and only handled requests. This PR:

- Uses the **idiomatic k8s `ResourceRequirements`** shape (matches the rest of the chart and k8s itself).
- Supports **both `requests` AND `limits`**, which is the actual ask in #935.
- Doesn't expand the env-var surface area (single `JOB_POD_RESOURCES` JSON blob vs. one env per field), and naturally extends to future `ResourceRequirements` fields like `claims`.

## Files changed

- `worker/constants/env.go` — add `EnvJobPodResources` constant.
- `worker/executor/kubernetes/executor.go` — extend `KubernetesConfig` with `JobPodResources *corev1.ResourceRequirements`; parse `JOB_POD_RESOURCES` JSON in `NewKubernetesExecutor` (same error-handling pattern as `POD_SECURITY_CONTEXT`).
- `worker/executor/kubernetes/pod.go` — extract a `buildJobPodResources()` helper that returns the override when set, falls back to historical defaults otherwise; replace the inline literal in `CreatePodSpec`.
- `helm/olake/templates/olake-worker/configmap.yaml` — emit `JOB_POD_RESOURCES` (JSON) when the value is set.
- `helm/olake/values.yaml` — document the new field with an example.

## How this has been tested

- [x] `go build ./...` and `go vet ./...` pass on `worker/`.
- [x] `helm lint helm/olake` passes.
- [x] `helm template` with `--set olakeWorker.jobPodResources.{requests,limits}.{cpu,memory}=...` correctly emits the JSON-encoded `JOB_POD_RESOURCES` configmap entry.
- [x] `helm template` with the value unset emits no `JOB_POD_RESOURCES` key (backward compatibility verified).
- [x] Verified `corev1.ResourceRequirements{}` round-trips cleanly through `json.Unmarshal` for both quoted (`"cpu":"2"`) and unquoted (`"cpu":2`) Quantity forms produced by Helm's `toJson`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change