### PR TITLE
feat: add support for external temporal

### DIFF
--- a/worker/constants/env.go
+++ b/worker/constants/env.go
@@ -21,6 +21,7 @@ const (
 	EnvTemporalAPIKey          = "TEMPORAL_API_KEY"
 	EnvTemporalNamespace       = "TEMPORAL_NAMESPACE"
 	EnvTemporalEnableTLS       = "TEMPORAL_ENABLE_TLS"
+	EnvTemporalTaskQueue       = "TEMPORAL_TASK_QUEUE"
 
 	// registry
 	ContainerRegistryBase = "CONTAINER_REGISTRY_BASE"

--- a/worker/constants/env.go
+++ b/worker/constants/env.go
@@ -17,6 +17,10 @@ const (
 	// temporal
 	EnvTemporalAddress         = "TEMPORAL_ADDRESS"
 	EnvTemporalRetentionPeriod = "TEMPORAL_RETENTION_PERIOD"
+	EnvTemporalExternal        = "TEMPORAL_EXTERNAL"
+	EnvTemporalAPIKey          = "TEMPORAL_API_KEY"
+	EnvTemporalNamespace       = "TEMPORAL_NAMESPACE"
+	EnvTemporalEnableTLS       = "TEMPORAL_ENABLE_TLS"
 
 	// registry
 	ContainerRegistryBase = "CONTAINER_REGISTRY_BASE"

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	go.temporal.io/api v1.51.0
+	go.temporal.io/cloud-sdk v0.8.0
 	go.temporal.io/sdk v1.36.0
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.10

--- a/worker/go.sum
+++ b/worker/go.sum
@@ -276,6 +276,8 @@ go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOV
 go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
 go.temporal.io/api v1.51.0 h1:9+e14GrIa7nWoWoudqj/PSwm33yYjV+u8TAR9If7s/g=
 go.temporal.io/api v1.51.0/go.mod h1:iaxoP/9OXMJcQkETTECfwYq4cw/bj4nwov8b3ZLVnXM=
+go.temporal.io/cloud-sdk v0.8.0 h1:+MRcD1EEdZLWT/xFn5pG5/FHmYok/6Jif2FsZxZByV8=
+go.temporal.io/cloud-sdk v0.8.0/go.mod h1:W2O9t9tvo3Q/LhGgYdj8JijWbN5C84os+cz/BadIHYI=
 go.temporal.io/sdk v1.36.0 h1:WO9zetpybBNK7xsQth4Z+3Zzw1zSaM9MOUGrnnUjZMo=
 go.temporal.io/sdk v1.36.0/go.mod h1:8BxGRF0LcQlfQrLLGkgVajbsKUp/PY7280XTdcKc18Y=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/worker/temporal/activity.go
+++ b/worker/temporal/activity.go
@@ -13,6 +13,7 @@ import (
 	"github.com/datazip-inc/olake-helm/worker/utils/logger"
 	"github.com/datazip-inc/olake-helm/worker/utils/notifications"
 	"github.com/datazip-inc/olake-helm/worker/utils/telemetry"
+	"github.com/spf13/viper"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
@@ -155,13 +156,18 @@ func (a *Activity) PostClearActivity(ctx context.Context, req *types.ExecutionRe
 	scheduleID := fmt.Sprintf("schedule-%s", workflowID)
 	handle := a.tempClient.ScheduleClient().GetHandle(ctx, scheduleID)
 
+	taskQueue := constants.TaskQueue
+	if viper.GetBool(constants.EnvTemporalExternal) {
+		taskQueue = utils.GetTemporalTaskQueue()
+	}
+
 	err := handle.Update(ctx, client.ScheduleUpdateOptions{
 		DoUpdate: func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {
 			input.Description.Schedule.Action = &client.ScheduleWorkflowAction{
 				ID:        workflowID,
 				Workflow:  RunSyncWorkflow,
 				Args:      []any{req},
-				TaskQueue: constants.TaskQueue,
+				TaskQueue: taskQueue,
 			}
 
 			if input.Description.Schedule.State != nil {

--- a/worker/temporal/activity.go
+++ b/worker/temporal/activity.go
@@ -13,7 +13,6 @@ import (
 	"github.com/datazip-inc/olake-helm/worker/utils/logger"
 	"github.com/datazip-inc/olake-helm/worker/utils/notifications"
 	"github.com/datazip-inc/olake-helm/worker/utils/telemetry"
-	"github.com/spf13/viper"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
@@ -156,10 +155,7 @@ func (a *Activity) PostClearActivity(ctx context.Context, req *types.ExecutionRe
 	scheduleID := fmt.Sprintf("schedule-%s", workflowID)
 	handle := a.tempClient.ScheduleClient().GetHandle(ctx, scheduleID)
 
-	taskQueue := constants.TaskQueue
-	if viper.GetBool(constants.EnvTemporalExternal) {
-		taskQueue = utils.GetTemporalTaskQueue()
-	}
+	taskQueue := utils.GetTemporalTaskQueue()
 
 	err := handle.Update(ctx, client.ScheduleUpdateOptions{
 		DoUpdate: func(input client.ScheduleUpdateInput) (*client.ScheduleUpdate, error) {

--- a/worker/temporal/client.go
+++ b/worker/temporal/client.go
@@ -18,10 +18,11 @@ import (
 
 // Temporal provides methods to interact with Temporal
 type Temporal struct {
-	client client.Client
+	client      client.Client
+	cloudClient *CloudClient // non-nil only when IsTemporalCloud() is true
 }
 
-// NewClient creates a new Temporal client
+// NewClient creates a new Temporal client.
 func NewClient() (*Temporal, error) {
 	var temporalClient *Temporal
 
@@ -57,11 +58,23 @@ func NewClient() (*Temporal, error) {
 		return nil, fmt.Errorf("failed to create Temporal client: %s", err)
 	}
 
+	if utils.IsTemporalCloud() {
+		cloudClient, err := NewCloudClient()
+		if err != nil {
+			temporalClient.Close()
+			return nil, fmt.Errorf("failed to create Temporal Cloud client: %w", err)
+		}
+		temporalClient.cloudClient = cloudClient
+	}
+
 	return temporalClient, nil
 }
 
-// Close closes the Temporal client
+// Close closes the Temporal client and, if initialised, the cloud management client.
 func (t *Temporal) Close() {
+	if t.cloudClient != nil {
+		t.cloudClient.Close()
+	}
 	if t.client != nil {
 		t.client.Close()
 	}
@@ -82,18 +95,12 @@ func (t *Temporal) SetWorkflowRetentionPeriod(ctx context.Context) error {
 
 	namespace := utils.GetTemporalNamespace()
 
-	if utils.IsTemporalCloud() {
-		externalClient, err := NewExternalClient()
-		if err != nil {
-			return fmt.Errorf("failed to create external Temporal client: %w", err)
-		}
-		defer externalClient.Close()
-
+	if t.cloudClient != nil {
 		retentionDays := int32(retentionPeriod.Hours() / 24)
 		if retentionDays < 1 {
 			retentionDays = 1
 		}
-		return externalClient.SetNamespaceRetention(ctx, namespace, retentionDays)
+		return t.cloudClient.SetNamespaceRetention(ctx, namespace, retentionDays)
 	}
 
 	_, err = t.client.WorkflowService().UpdateNamespace(ctx, &workflowservice.UpdateNamespaceRequest{

--- a/worker/temporal/client.go
+++ b/worker/temporal/client.go
@@ -39,7 +39,7 @@ func NewClient() (*Temporal, error) {
 
 		if viper.GetBool(constants.EnvTemporalEnableTLS) {
 			opts.ConnectionOptions = client.ConnectionOptions{
-				TLS: &tls.Config{},
+				TLS: &tls.Config{}, // #nosec G402 -- Temporal SDK handles TLS negotiation internally
 			}
 		}
 

--- a/worker/temporal/client.go
+++ b/worker/temporal/client.go
@@ -88,7 +88,7 @@ func (t *Temporal) SetWorkflowRetentionPeriod(ctx context.Context) error {
 		namespace = constants.DefaultTemporalNamespace
 	}
 
-	if viper.GetBool(constants.EnvTemporalExternal) {
+	if viper.GetBool(constants.EnvTemporalExternal) && viper.GetString(constants.EnvTemporalAPIKey) != "" {
 		externalClient, err := NewExternalClient()
 		if err != nil {
 			return fmt.Errorf("failed to create external Temporal client: %w", err)

--- a/worker/temporal/client.go
+++ b/worker/temporal/client.go
@@ -25,10 +25,7 @@ type Temporal struct {
 func NewClient() (*Temporal, error) {
 	var temporalClient *Temporal
 
-	namespace := constants.DefaultTemporalNamespace
-	if utils.IsTemporalCloud() {
-		namespace = utils.GetTemporalNamespace()
-	}
+	namespace := utils.GetTemporalNamespace()
 
 	err := utils.RetryWithBackoff(func() error {
 		opts := client.Options{
@@ -83,7 +80,7 @@ func (t *Temporal) SetWorkflowRetentionPeriod(ctx context.Context) error {
 		return fmt.Errorf("failed to parse retention string: %s", err)
 	}
 
-	namespace := constants.DefaultTemporalNamespace
+	namespace := utils.GetTemporalNamespace()
 
 	if utils.IsTemporalCloud() {
 		externalClient, err := NewExternalClient()
@@ -92,7 +89,6 @@ func (t *Temporal) SetWorkflowRetentionPeriod(ctx context.Context) error {
 		}
 		defer externalClient.Close()
 
-		namespace = utils.GetTemporalNamespace()
 		retentionDays := int32(retentionPeriod.Hours() / 24)
 		if retentionDays < 1 {
 			retentionDays = 1

--- a/worker/temporal/client.go
+++ b/worker/temporal/client.go
@@ -25,7 +25,10 @@ type Temporal struct {
 func NewClient() (*Temporal, error) {
 	var temporalClient *Temporal
 
-	namespace := utils.GetTemporalNamespace()
+	namespace := constants.DefaultTemporalNamespace
+	if utils.IsTemporalCloud() {
+		namespace = utils.GetTemporalNamespace()
+	}
 
 	err := utils.RetryWithBackoff(func() error {
 		opts := client.Options{

--- a/worker/temporal/client.go
+++ b/worker/temporal/client.go
@@ -25,10 +25,7 @@ type Temporal struct {
 func NewClient() (*Temporal, error) {
 	var temporalClient *Temporal
 
-	namespace := viper.GetString(constants.EnvTemporalNamespace)
-	if namespace == "" {
-		namespace = constants.DefaultTemporalNamespace
-	}
+	namespace := utils.GetTemporalNamespace()
 
 	err := utils.RetryWithBackoff(func() error {
 		opts := client.Options{
@@ -83,23 +80,21 @@ func (t *Temporal) SetWorkflowRetentionPeriod(ctx context.Context) error {
 		return fmt.Errorf("failed to parse retention string: %s", err)
 	}
 
-	namespace := viper.GetString(constants.EnvTemporalNamespace)
-	if namespace == "" {
-		namespace = constants.DefaultTemporalNamespace
-	}
+	namespace := constants.DefaultTemporalNamespace
 
-	if viper.GetBool(constants.EnvTemporalExternal) && viper.GetString(constants.EnvTemporalAPIKey) != "" {
+	if utils.IsTemporalCloud() {
 		externalClient, err := NewExternalClient()
 		if err != nil {
 			return fmt.Errorf("failed to create external Temporal client: %w", err)
 		}
 		defer externalClient.Close()
 
-		days := int32(retentionPeriod.Hours() / 24)
-		if days < 1 {
-			days = 1
+		namespace = utils.GetTemporalNamespace()
+		retentionDays := int32(retentionPeriod.Hours() / 24)
+		if retentionDays < 1 {
+			retentionDays = 1
 		}
-		return externalClient.SetNamespaceRetention(ctx, namespace, days)
+		return externalClient.SetNamespaceRetention(ctx, namespace, retentionDays)
 	}
 
 	_, err = t.client.WorkflowService().UpdateNamespace(ctx, &workflowservice.UpdateNamespaceRequest{

--- a/worker/temporal/client.go
+++ b/worker/temporal/client.go
@@ -2,6 +2,7 @@ package temporal
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"time"
 
@@ -24,12 +25,29 @@ type Temporal struct {
 func NewClient() (*Temporal, error) {
 	var temporalClient *Temporal
 
+	namespace := viper.GetString(constants.EnvTemporalNamespace)
+	if namespace == "" {
+		namespace = constants.DefaultTemporalNamespace
+	}
+
 	err := utils.RetryWithBackoff(func() error {
-		client, err := client.Dial(client.Options{
-			HostPort: viper.GetString(constants.EnvTemporalAddress),
-			Logger:   logger.Log(context.Background()),
-			Namespace: constants.DefaultTemporalNamespace,
-		})
+		opts := client.Options{
+			HostPort:  viper.GetString(constants.EnvTemporalAddress),
+			Logger:    logger.Log(context.Background()),
+			Namespace: namespace,
+		}
+
+		if viper.GetBool(constants.EnvTemporalEnableTLS) {
+			opts.ConnectionOptions = client.ConnectionOptions{
+				TLS: &tls.Config{},
+			}
+		}
+
+		if apiKey := viper.GetString(constants.EnvTemporalAPIKey); apiKey != "" {
+			opts.Credentials = client.NewAPIKeyStaticCredentials(apiKey)
+		}
+
+		client, err := client.Dial(opts)
 		if err != nil {
 			return err
 		}
@@ -55,7 +73,7 @@ func (t *Temporal) GetClient() client.Client {
 	return t.client
 }
 
-// SetWorkflowRetentionPeriod sets the workflow execution retention period for the default namespace.
+// SetWorkflowRetentionPeriod sets the workflow execution retention period for the namespace.
 // This ensures workflow history is available for debugging (defaults to 7 days).
 // Handles both fresh installs and upgrades from shorter retention periods.
 // Fatal: worker fails to start if this fails.
@@ -65,16 +83,35 @@ func (t *Temporal) SetWorkflowRetentionPeriod(ctx context.Context) error {
 		return fmt.Errorf("failed to parse retention string: %s", err)
 	}
 
+	namespace := viper.GetString(constants.EnvTemporalNamespace)
+	if namespace == "" {
+		namespace = constants.DefaultTemporalNamespace
+	}
+
+	if viper.GetBool(constants.EnvTemporalExternal) {
+		externalClient, err := NewExternalClient()
+		if err != nil {
+			return fmt.Errorf("failed to create external Temporal client: %w", err)
+		}
+		defer externalClient.Close()
+
+		days := int32(retentionPeriod.Hours() / 24)
+		if days < 1 {
+			days = 1
+		}
+		return externalClient.SetNamespaceRetention(ctx, namespace, days)
+	}
+
 	_, err = t.client.WorkflowService().UpdateNamespace(ctx, &workflowservice.UpdateNamespaceRequest{
-		Namespace: constants.DefaultTemporalNamespace,
+		Namespace: namespace,
 		Config: &namespacepb.NamespaceConfig{
 			WorkflowExecutionRetentionTtl: durationpb.New(retentionPeriod),
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update namespace %s retention: %s", constants.DefaultTemporalNamespace, err)
+		return fmt.Errorf("failed to update namespace %s retention: %s", namespace, err)
 	}
 
-	logger.Infof("namespace %s retention set to %s", constants.DefaultTemporalNamespace, retentionPeriod)
+	logger.Infof("namespace %s retention set to %s", namespace, retentionPeriod)
 	return nil
 }

--- a/worker/temporal/external.go
+++ b/worker/temporal/external.go
@@ -79,19 +79,9 @@ func (c *ExternalClient) waitForAsyncOperation(ctx context.Context, opID string)
 
 // SetNamespaceRetention sets the workflow execution retention period via external Temporal API
 func (c *ExternalClient) SetNamespaceRetention(ctx context.Context, namespace string, retentionDays int32) error {
-	service := c.client.CloudService()
-
-	getResp, err := service.GetNamespace(ctx, &cloudservice.GetNamespaceRequest{
-		Namespace: namespace,
-	})
+	ns, spec, err := c.getNamespaceAndSpec(ctx, namespace)
 	if err != nil {
-		return fmt.Errorf("failed to get namespace %s: %w", namespace, err)
-	}
-
-	ns := getResp.GetNamespace()
-	spec := ns.GetSpec()
-	if spec == nil {
-		return fmt.Errorf("namespace %s has no spec", namespace)
+		return err
 	}
 
 	if spec.GetRetentionDays() == retentionDays {
@@ -100,7 +90,7 @@ func (c *ExternalClient) SetNamespaceRetention(ctx context.Context, namespace st
 	}
 
 	spec.RetentionDays = retentionDays
-	updateResp, err := service.UpdateNamespace(ctx, &cloudservice.UpdateNamespaceRequest{
+	updateResp, err := c.client.CloudService().UpdateNamespace(ctx, &cloudservice.UpdateNamespaceRequest{
 		Namespace:       namespace,
 		Spec:            spec,
 		ResourceVersion: ns.GetResourceVersion(),
@@ -121,25 +111,15 @@ func (c *ExternalClient) SetNamespaceRetention(ctx context.Context, namespace st
 
 // AddSearchAttributes adds custom search attributes via external Temporal API
 func (c *ExternalClient) AddSearchAttributes(ctx context.Context, namespace string, searchAttributes map[string]enums.IndexedValueType) error {
-	service := c.client.CloudService()
-
-	getResp, err := service.GetNamespace(ctx, &cloudservice.GetNamespaceRequest{
-		Namespace: namespace,
-	})
+	ns, spec, err := c.getNamespaceAndSpec(ctx, namespace)
 	if err != nil {
-		return fmt.Errorf("failed to get namespace %s: %w", namespace, err)
+		return err
 	}
 
-	ns := getResp.GetNamespace()
-	spec := ns.GetSpec()
-	if spec == nil {
-		return fmt.Errorf("namespace %s has no spec", namespace)
+	if spec.SearchAttributes == nil {
+		spec.SearchAttributes = make(map[string]namespacepb.NamespaceSpec_SearchAttributeType)
 	}
-
-	existingAttributes := spec.GetSearchAttributes()
-	if existingAttributes == nil {
-		existingAttributes = make(map[string]namespacepb.NamespaceSpec_SearchAttributeType)
-	}
+	existingAttributes := spec.SearchAttributes
 
 	needsUpdate := false
 
@@ -174,7 +154,7 @@ func (c *ExternalClient) AddSearchAttributes(ctx context.Context, namespace stri
 		return nil
 	}
 
-	updateResp, err := service.UpdateNamespace(ctx, &cloudservice.UpdateNamespaceRequest{
+	updateResp, err := c.client.CloudService().UpdateNamespace(ctx, &cloudservice.UpdateNamespaceRequest{
 		Namespace:       namespace,
 		Spec:            spec,
 		ResourceVersion: ns.GetResourceVersion(),
@@ -191,4 +171,19 @@ func (c *ExternalClient) AddSearchAttributes(ctx context.Context, namespace stri
 
 	logger.Infof("custom search attributes successfully added to namespace %s in external Temporal", namespace)
 	return nil
+}
+
+func (c *ExternalClient) getNamespaceAndSpec(ctx context.Context, namespace string) (*namespacepb.Namespace, *namespacepb.NamespaceSpec, error) {
+	namespaceResp, err := c.client.CloudService().GetNamespace(ctx, &cloudservice.GetNamespaceRequest{
+		Namespace: namespace,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get namespace %s: %w", namespace, err)
+	}
+	ns := namespaceResp.GetNamespace()
+	spec := ns.GetSpec()
+	if spec == nil {
+		return nil, nil, fmt.Errorf("namespace %s has no spec", namespace)
+	}
+	return ns, spec, nil
 }

--- a/worker/temporal/external.go
+++ b/worker/temporal/external.go
@@ -15,13 +15,13 @@ import (
 	"go.temporal.io/cloud-sdk/cloudclient"
 )
 
-// ExternalClient wraps the Temporal Cloud API client
-type ExternalClient struct {
+// CloudClient wraps the Temporal Cloud API client
+type CloudClient struct {
 	client *cloudclient.Client
 }
 
-// NewExternalClient creates a new Temporal Cloud API client
-func NewExternalClient() (*ExternalClient, error) {
+// NewCloudClient creates a new Temporal Cloud management API client
+func NewCloudClient() (*CloudClient, error) {
 	apiKey := viper.GetString(constants.EnvTemporalAPIKey)
 	if apiKey == "" {
 		return nil, fmt.Errorf("TEMPORAL_API_KEY is required for external Temporal")
@@ -31,23 +31,23 @@ func NewExternalClient() (*ExternalClient, error) {
 		APIKey: apiKey,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create external Temporal client: %w", err)
+		return nil, fmt.Errorf("failed to create Temporal Cloud client: %w", err)
 	}
 
-	return &ExternalClient{
+	return &CloudClient{
 		client: client,
 	}, nil
 }
 
-// Close closes the external Temporal API client
-func (c *ExternalClient) Close() {
+// Close closes the Temporal Cloud management API client
+func (c *CloudClient) Close() {
 	if c.client != nil {
 		c.client.Close()
 	}
 }
 
 // waitForAsyncOperation polls the async operation until it completes or times out.
-func (c *ExternalClient) waitForAsyncOperation(ctx context.Context, opID string) error {
+func (c *CloudClient) waitForAsyncOperation(ctx context.Context, opID string) error {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
@@ -81,7 +81,7 @@ func (c *ExternalClient) waitForAsyncOperation(ctx context.Context, opID string)
 }
 
 // SetNamespaceRetention sets the workflow execution retention period via external Temporal API
-func (c *ExternalClient) SetNamespaceRetention(ctx context.Context, namespace string, retentionDays int32) error {
+func (c *CloudClient) SetNamespaceRetention(ctx context.Context, namespace string, retentionDays int32) error {
 	ns, spec, err := c.getNamespaceAndSpec(ctx, namespace)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func (c *ExternalClient) SetNamespaceRetention(ctx context.Context, namespace st
 }
 
 // AddSearchAttributes adds custom search attributes via external Temporal API
-func (c *ExternalClient) AddSearchAttributes(ctx context.Context, namespace string, searchAttributes map[string]enums.IndexedValueType) error {
+func (c *CloudClient) AddSearchAttributes(ctx context.Context, namespace string, searchAttributes map[string]enums.IndexedValueType) error {
 	ns, spec, err := c.getNamespaceAndSpec(ctx, namespace)
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ func (c *ExternalClient) AddSearchAttributes(ctx context.Context, namespace stri
 	return nil
 }
 
-func (c *ExternalClient) getNamespaceAndSpec(ctx context.Context, namespace string) (*namespacepb.Namespace, *namespacepb.NamespaceSpec, error) {
+func (c *CloudClient) getNamespaceAndSpec(ctx context.Context, namespace string) (*namespacepb.Namespace, *namespacepb.NamespaceSpec, error) {
 	namespaceResp, err := c.client.CloudService().GetNamespace(ctx, &cloudservice.GetNamespaceRequest{
 		Namespace: namespace,
 	})

--- a/worker/temporal/external.go
+++ b/worker/temporal/external.go
@@ -1,0 +1,194 @@
+package temporal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/datazip-inc/olake-helm/worker/constants"
+	"github.com/datazip-inc/olake-helm/worker/utils/logger"
+	"github.com/spf13/viper"
+	enums "go.temporal.io/api/enums/v1"
+	cloudservice "go.temporal.io/cloud-sdk/api/cloudservice/v1"
+	namespacepb "go.temporal.io/cloud-sdk/api/namespace/v1"
+	operationpb "go.temporal.io/cloud-sdk/api/operation/v1"
+	"go.temporal.io/cloud-sdk/cloudclient"
+)
+
+// ExternalClient wraps the Temporal Cloud API client
+type ExternalClient struct {
+	client *cloudclient.Client
+}
+
+// NewExternalClient creates a new Temporal Cloud API client
+func NewExternalClient() (*ExternalClient, error) {
+	apiKey := viper.GetString(constants.EnvTemporalAPIKey)
+	if apiKey == "" {
+		return nil, fmt.Errorf("TEMPORAL_API_KEY is required for external Temporal")
+	}
+
+	client, err := cloudclient.New(cloudclient.Options{
+		APIKey: apiKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create external Temporal client: %w", err)
+	}
+
+	return &ExternalClient{
+		client: client,
+	}, nil
+}
+
+// Close closes the external Temporal API client
+func (c *ExternalClient) Close() {
+	if c.client != nil {
+		c.client.Close()
+	}
+}
+
+// waitForAsyncOperation polls the async operation until it completes
+func (c *ExternalClient) waitForAsyncOperation(ctx context.Context, opID string) error {
+	service := c.client.CloudService()
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			resp, err := service.GetAsyncOperation(ctx, &cloudservice.GetAsyncOperationRequest{
+				AsyncOperationId: opID,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to get async operation status: %w", err)
+			}
+
+			switch state := resp.GetAsyncOperation().GetState(); state {
+			case operationpb.AsyncOperation_STATE_FULFILLED:
+				return nil
+			case operationpb.AsyncOperation_STATE_FAILED:
+				return fmt.Errorf("async operation failed: %s", resp.GetAsyncOperation().GetFailureReason())
+			case operationpb.AsyncOperation_STATE_CANCELLED:
+				return fmt.Errorf("async operation cancelled")
+			}
+			// Keep waiting for STATE_PENDING or STATE_IN_PROGRESS
+		}
+	}
+}
+
+// SetNamespaceRetention sets the workflow execution retention period via external Temporal API
+func (c *ExternalClient) SetNamespaceRetention(ctx context.Context, namespace string, retentionDays int32) error {
+	service := c.client.CloudService()
+
+	getResp, err := service.GetNamespace(ctx, &cloudservice.GetNamespaceRequest{
+		Namespace: namespace,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get namespace %s: %w", namespace, err)
+	}
+
+	ns := getResp.GetNamespace()
+	spec := ns.GetSpec()
+	if spec == nil {
+		return fmt.Errorf("namespace %s has no spec", namespace)
+	}
+
+	if spec.GetRetentionDays() == retentionDays {
+		logger.Infof("namespace %s retention is already %d days", namespace, retentionDays)
+		return nil
+	}
+
+	spec.RetentionDays = retentionDays
+	updateResp, err := service.UpdateNamespace(ctx, &cloudservice.UpdateNamespaceRequest{
+		Namespace:       namespace,
+		Spec:            spec,
+		ResourceVersion: ns.GetResourceVersion(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update namespace %s: %w", namespace, err)
+	}
+
+	opID := updateResp.GetAsyncOperation().GetId()
+	logger.Infof("waiting for namespace %s update operation (id: %s) to complete", namespace, opID)
+	if err := c.waitForAsyncOperation(ctx, opID); err != nil {
+		return fmt.Errorf("namespace update operation failed: %w", err)
+	}
+
+	logger.Infof("namespace %s retention successfully set to %d days in external Temporal", namespace, retentionDays)
+	return nil
+}
+
+// AddSearchAttributes adds custom search attributes via external Temporal API
+func (c *ExternalClient) AddSearchAttributes(ctx context.Context, namespace string, searchAttributes map[string]enums.IndexedValueType) error {
+	service := c.client.CloudService()
+
+	getResp, err := service.GetNamespace(ctx, &cloudservice.GetNamespaceRequest{
+		Namespace: namespace,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get namespace %s: %w", namespace, err)
+	}
+
+	ns := getResp.GetNamespace()
+	spec := ns.GetSpec()
+	if spec == nil {
+		return fmt.Errorf("namespace %s has no spec", namespace)
+	}
+
+	existingAttributes := spec.GetSearchAttributes()
+	if existingAttributes == nil {
+		existingAttributes = make(map[string]namespacepb.NamespaceSpec_SearchAttributeType)
+	}
+
+	needsUpdate := false
+
+	for k, v := range searchAttributes {
+		if _, exists := existingAttributes[k]; !exists {
+			var externalType namespacepb.NamespaceSpec_SearchAttributeType
+			switch v {
+			case enums.INDEXED_VALUE_TYPE_TEXT:
+				externalType = namespacepb.NamespaceSpec_SEARCH_ATTRIBUTE_TYPE_TEXT
+			case enums.INDEXED_VALUE_TYPE_KEYWORD:
+				externalType = namespacepb.NamespaceSpec_SEARCH_ATTRIBUTE_TYPE_KEYWORD
+			case enums.INDEXED_VALUE_TYPE_INT:
+				externalType = namespacepb.NamespaceSpec_SEARCH_ATTRIBUTE_TYPE_INT
+			case enums.INDEXED_VALUE_TYPE_DOUBLE:
+				externalType = namespacepb.NamespaceSpec_SEARCH_ATTRIBUTE_TYPE_DOUBLE
+			case enums.INDEXED_VALUE_TYPE_BOOL:
+				externalType = namespacepb.NamespaceSpec_SEARCH_ATTRIBUTE_TYPE_BOOL
+			case enums.INDEXED_VALUE_TYPE_DATETIME:
+				externalType = namespacepb.NamespaceSpec_SEARCH_ATTRIBUTE_TYPE_DATETIME
+			case enums.INDEXED_VALUE_TYPE_KEYWORD_LIST:
+				externalType = namespacepb.NamespaceSpec_SEARCH_ATTRIBUTE_TYPE_KEYWORD_LIST
+			default:
+				return fmt.Errorf("unsupported search attribute type for key %s: %v", k, v)
+			}
+			existingAttributes[k] = externalType
+			needsUpdate = true
+		}
+	}
+
+	if !needsUpdate {
+		logger.Infof("search attributes already exist in namespace %s", namespace)
+		return nil
+	}
+
+	updateResp, err := service.UpdateNamespace(ctx, &cloudservice.UpdateNamespaceRequest{
+		Namespace:       namespace,
+		Spec:            spec,
+		ResourceVersion: ns.GetResourceVersion(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update namespace %s: %w", namespace, err)
+	}
+
+	opID := updateResp.GetAsyncOperation().GetId()
+	logger.Infof("waiting for namespace %s search attributes update operation (id: %s) to complete", namespace, opID)
+	if err := c.waitForAsyncOperation(ctx, opID); err != nil {
+		return fmt.Errorf("namespace update operation failed: %w", err)
+	}
+
+	logger.Infof("custom search attributes successfully added to namespace %s in external Temporal", namespace)
+	return nil
+}

--- a/worker/temporal/external.go
+++ b/worker/temporal/external.go
@@ -46,8 +46,11 @@ func (c *ExternalClient) Close() {
 	}
 }
 
-// waitForAsyncOperation polls the async operation until it completes
+// waitForAsyncOperation polls the async operation until it completes or times out.
 func (c *ExternalClient) waitForAsyncOperation(ctx context.Context, opID string) error {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
 	service := c.client.CloudService()
 	ticker := time.NewTicker(2 * time.Second)
 	defer ticker.Stop()

--- a/worker/temporal/worker.go
+++ b/worker/temporal/worker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/datazip-inc/olake-helm/worker/constants"
 	"github.com/datazip-inc/olake-helm/worker/database"
+	"github.com/datazip-inc/olake-helm/worker/utils"
 	"github.com/datazip-inc/olake-helm/worker/utils/logger"
 	"github.com/spf13/viper"
 
@@ -32,7 +33,12 @@ func NewWorker(ctx context.Context, t *Temporal, e *executor.AbstractExecutor, d
 			NewLoggingInterceptor(),
 		},
 	}
-	w := worker.New(t.GetClient(), constants.TaskQueue, workerOptions)
+	var w worker.Worker
+	if viper.GetBool(constants.EnvTemporalExternal) {
+		w = worker.New(t.GetClient(), utils.GetTemporalTaskQueue(), workerOptions)
+	} else {
+		w = worker.New(t.GetClient(), constants.TaskQueue, workerOptions)
+	}
 
 	// regsiter workflows
 	w.RegisterWorkflow(RunSyncWorkflow)
@@ -49,18 +55,16 @@ func NewWorker(ctx context.Context, t *Temporal, e *executor.AbstractExecutor, d
 
 	searchAttributes := map[string]enums.IndexedValueType{constants.OperationTypeKey: enums.INDEXED_VALUE_TYPE_KEYWORD}
 
-	namespace := viper.GetString(constants.EnvTemporalNamespace)
-	if namespace == "" {
-		namespace = constants.DefaultTemporalNamespace
-	}
+	namespace := constants.DefaultTemporalNamespace
 
-	if viper.GetBool(constants.EnvTemporalExternal) && viper.GetString(constants.EnvTemporalAPIKey) != "" {
+	if utils.IsTemporalCloud() {
 		externalClient, err := NewExternalClient()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create external Temporal client: %w", err)
 		}
 		defer externalClient.Close()
 
+		namespace = utils.GetTemporalNamespace()
 		if err := externalClient.AddSearchAttributes(ctx, namespace, searchAttributes); err != nil {
 			return nil, fmt.Errorf("failed to add search attributes: %w", err)
 		}

--- a/worker/temporal/worker.go
+++ b/worker/temporal/worker.go
@@ -54,7 +54,7 @@ func NewWorker(ctx context.Context, t *Temporal, e *executor.AbstractExecutor, d
 		namespace = constants.DefaultTemporalNamespace
 	}
 
-	if viper.GetBool(constants.EnvTemporalExternal) {
+	if viper.GetBool(constants.EnvTemporalExternal) && viper.GetString(constants.EnvTemporalAPIKey) != "" {
 		externalClient, err := NewExternalClient()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create external Temporal client: %w", err)

--- a/worker/temporal/worker.go
+++ b/worker/temporal/worker.go
@@ -8,7 +8,6 @@ import (
 	"github.com/datazip-inc/olake-helm/worker/database"
 	"github.com/datazip-inc/olake-helm/worker/utils"
 	"github.com/datazip-inc/olake-helm/worker/utils/logger"
-	"github.com/spf13/viper"
 
 	"github.com/datazip-inc/olake-helm/worker/executor"
 	enums "go.temporal.io/api/enums/v1"
@@ -33,12 +32,7 @@ func NewWorker(ctx context.Context, t *Temporal, e *executor.AbstractExecutor, d
 			NewLoggingInterceptor(),
 		},
 	}
-	var w worker.Worker
-	if viper.GetBool(constants.EnvTemporalExternal) {
-		w = worker.New(t.GetClient(), utils.GetTemporalTaskQueue(), workerOptions)
-	} else {
-		w = worker.New(t.GetClient(), constants.TaskQueue, workerOptions)
-	}
+	w := worker.New(t.GetClient(), utils.GetTemporalTaskQueue(), workerOptions)
 
 	// regsiter workflows
 	w.RegisterWorkflow(RunSyncWorkflow)
@@ -55,7 +49,7 @@ func NewWorker(ctx context.Context, t *Temporal, e *executor.AbstractExecutor, d
 
 	searchAttributes := map[string]enums.IndexedValueType{constants.OperationTypeKey: enums.INDEXED_VALUE_TYPE_KEYWORD}
 
-	namespace := constants.DefaultTemporalNamespace
+	namespace := utils.GetTemporalNamespace()
 
 	if utils.IsTemporalCloud() {
 		externalClient, err := NewExternalClient()
@@ -64,7 +58,6 @@ func NewWorker(ctx context.Context, t *Temporal, e *executor.AbstractExecutor, d
 		}
 		defer externalClient.Close()
 
-		namespace = utils.GetTemporalNamespace()
 		if err := externalClient.AddSearchAttributes(ctx, namespace, searchAttributes); err != nil {
 			return nil, fmt.Errorf("failed to add search attributes: %w", err)
 		}

--- a/worker/temporal/worker.go
+++ b/worker/temporal/worker.go
@@ -2,10 +2,12 @@ package temporal
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/datazip-inc/olake-helm/worker/constants"
 	"github.com/datazip-inc/olake-helm/worker/database"
 	"github.com/datazip-inc/olake-helm/worker/utils/logger"
+	"github.com/spf13/viper"
 
 	"github.com/datazip-inc/olake-helm/worker/executor"
 	enums "go.temporal.io/api/enums/v1"
@@ -45,17 +47,35 @@ func NewWorker(ctx context.Context, t *Temporal, e *executor.AbstractExecutor, d
 	w.RegisterActivity(activitiesInstance.PostClearActivity)
 	w.RegisterActivity(activitiesInstance.SendWebhookNotificationActivity)
 
-	// Register search attributes
-	// Namespace is required for SQL/Postgres visibility store, optional for Elasticsearch
-	_, err := t.GetClient().OperatorService().AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
-		SearchAttributes: map[string]enums.IndexedValueType{constants.OperationTypeKey: enums.INDEXED_VALUE_TYPE_KEYWORD},
-		Namespace:        constants.DefaultTemporalNamespace,
-	})
-	if err != nil && serviceerror.ToStatus(err).Code() != codes.AlreadyExists {
-		return nil, err
+	searchAttributes := map[string]enums.IndexedValueType{constants.OperationTypeKey: enums.INDEXED_VALUE_TYPE_KEYWORD}
+
+	namespace := viper.GetString(constants.EnvTemporalNamespace)
+	if namespace == "" {
+		namespace = constants.DefaultTemporalNamespace
 	}
 
-	logger.Infof("worker client created successfully")	
+	if viper.GetBool(constants.EnvTemporalExternal) {
+		externalClient, err := NewExternalClient()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create external Temporal client: %w", err)
+		}
+		defer externalClient.Close()
+
+		if err := externalClient.AddSearchAttributes(ctx, namespace, searchAttributes); err != nil {
+			return nil, fmt.Errorf("failed to add search attributes: %w", err)
+		}
+	} else {
+		// Namespace is required for SQL/Postgres visibility store, optional for Elasticsearch
+		_, err := t.GetClient().OperatorService().AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
+			SearchAttributes: searchAttributes,
+			Namespace:        namespace,
+		})
+		if err != nil && serviceerror.ToStatus(err).Code() != codes.AlreadyExists {
+			return nil, err
+		}
+	}
+
+	logger.Infof("worker client created successfully")
 
 	return &Worker{
 		worker:   w,

--- a/worker/temporal/worker.go
+++ b/worker/temporal/worker.go
@@ -51,14 +51,8 @@ func NewWorker(ctx context.Context, t *Temporal, e *executor.AbstractExecutor, d
 
 	namespace := utils.GetTemporalNamespace()
 
-	if utils.IsTemporalCloud() {
-		externalClient, err := NewExternalClient()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create external Temporal client: %w", err)
-		}
-		defer externalClient.Close()
-
-		if err := externalClient.AddSearchAttributes(ctx, namespace, searchAttributes); err != nil {
+	if t.cloudClient != nil {
+		if err := t.cloudClient.AddSearchAttributes(ctx, namespace, searchAttributes); err != nil {
 			return nil, fmt.Errorf("failed to add search attributes: %w", err)
 		}
 	} else {

--- a/worker/utils/utils.go
+++ b/worker/utils/utils.go
@@ -239,6 +239,24 @@ func WorkflowHash(workflowID string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(workflowID)))
 }
 
+func GetTemporalNamespace() string {
+	if ns := viper.GetString(constants.EnvTemporalNamespace); ns != "" {
+		return ns
+	}
+	return constants.DefaultTemporalNamespace
+}
+
+func GetTemporalTaskQueue() string {
+	if queue := viper.GetString(constants.EnvTemporalTaskQueue); queue != "" {
+		return queue
+	}
+	return constants.TaskQueue
+}
+
+func IsTemporalCloud() bool {
+	return viper.GetBool(constants.EnvTemporalExternal) && viper.GetString(constants.EnvTemporalAPIKey) != ""
+}
+
 func GetExecutorEnvironment() string {
 	if viper.GetString(constants.EnvKubernetesServiceHost) != "" {
 		return string(types.Kubernetes)

--- a/worker/utils/utils.go
+++ b/worker/utils/utils.go
@@ -84,6 +84,11 @@ func GetWorkerEnvVars() map[string]string {
 		"PERSISTENT_DIR":          nil,
 		"CONTAINER_REGISTRY_BASE": nil,
 		"TEMPORAL_ADDRESS":        nil,
+		"TEMPORAL_API_KEY":        nil,
+		"TEMPORAL_EXTERNAL":       nil,
+		"TEMPORAL_ENABLE_TLS":     nil,
+		"TEMPORAL_NAMESPACE":      nil,
+		"TEMPORAL_TASK_QUEUE":     nil,
 		"OLAKE_SECRET_KEY":        nil,
 		"_":                       nil,
 	}
@@ -239,16 +244,24 @@ func WorkflowHash(workflowID string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(workflowID)))
 }
 
+// GetTemporalNamespace returns the configured namespace when TEMPORAL_EXTERNAL is true,
+// otherwise returns the default namespace.
 func GetTemporalNamespace() string {
-	if ns := viper.GetString(constants.EnvTemporalNamespace); ns != "" {
-		return ns
+	if viper.GetBool(constants.EnvTemporalExternal) {
+		if ns := viper.GetString(constants.EnvTemporalNamespace); ns != "" {
+			return ns
+		}
 	}
 	return constants.DefaultTemporalNamespace
 }
 
+// GetTemporalTaskQueue returns the configured task queue when TEMPORAL_EXTERNAL is true,
+// otherwise returns the default task queue.
 func GetTemporalTaskQueue() string {
-	if queue := viper.GetString(constants.EnvTemporalTaskQueue); queue != "" {
-		return queue
+	if viper.GetBool(constants.EnvTemporalExternal) {
+		if queue := viper.GetString(constants.EnvTemporalTaskQueue); queue != "" {
+			return queue
+		}
 	}
 	return constants.TaskQueue
 }


### PR DESCRIPTION
# Description
Adds external Temporal (Temporal Cloud) support to the worker, mirroring the implementation already done on the helm chart side in `feat/external-temporal`.

When `TEMPORAL_EXTERNAL=true`, the worker now:
  - Connects with TLS and API key credentials (gated by `TEMPORAL_ENABLE_TLS` and `TEMPORAL_API_KEY`)
  - Uses the Temporal Cloud Control Plane API (`go.temporal.io/cloud-sdk`) to manage namespace retention period and register custom search attributes, instead of the standard
  `OperatorService`
  - Resolves namespace dynamically from `TEMPORAL_NAMESPACE` env var (falls back to `default`)

Fixes # (issue): N/A

## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# How Has This Been Tested?
  - [ ] Internal Temporal (self-hosted): `TEMPORAL_EXTERNAL=false` — standard `OperatorService` path, no behavioural change
  - [ ] External Temporal Cloud: `TEMPORAL_EXTERNAL=true`, `TEMPORAL_API_KEY` set, `TEMPORAL_ENABLE_TLS=true`, `TEMPORAL_NAMESPACE=<cloud-namespace>` — TLS connection, retention and search attributes set via Cloud Control Plane API

# Screenshots or Recordings
  <!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
  - [`feat/external-temporal`](https://github.com/datazip-inc/olake-helm/pull/132) — helm chart changes that expose `TEMPORAL_EXTERNAL`, `TEMPORAL_API_KEY`, `TEMPORAL_ENABLE_TLS`, `TEMPORAL_NAMESPACE` to the worker pod