### PR TITLE
feat(fusion): add podLabels and podAnnotations hooks

### DIFF
--- a/helm/olake/templates/fusion/deployment.yaml
+++ b/helm/olake/templates/fusion/deployment.yaml
@@ -24,8 +24,14 @@ spec:
         app.kubernetes.io/name: {{ include "olake.name" . }}-fusion
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: fusion
+        {{- with .Values.fusion.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/fusion-config: {{ include (print $.Template.BasePath "/fusion/configmap.yaml") . | sha256sum }}
+        {{- with .Values.fusion.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.fusion.nodeSelector }}
       nodeSelector:

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -630,7 +630,13 @@ fusion:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  
+
+  # -- Additional pod annotations
+  podAnnotations: {}
+
+  # -- Additional pod labels
+  podLabels: {}
+
   # --- Amoro config shade properties
   shade:
     identifier: "default"


### PR DESCRIPTION
## Summary

Every other component in this chart — `olake-ui`, `olake-worker`, `temporal`, `postgresql`, `nfs-server`, `elasticsearch` — exposes `podLabels` and `podAnnotations` value blocks that get merged into `spec.template.metadata`. The Fusion deployment template is the only one missing both. Its pod-template metadata is hardcoded to the `app.kubernetes.io/*` labels and the config-checksum annotation, with no operator extension point.

This matters for deployments running under K8s admission policies that require specific labels on pod templates (Gatekeeper / Kyverno / OPA constraints, internal compliance tags, mesh-routing labels, etc.). Without a `podLabels` hook, operators either have to live with policy warnings on the Fusion pod or carry a parent-chart patch.

Real-world example: my deployment runs under a Gatekeeper `template-required-labels-warn` constraint requiring `meta.zego.tools/{managed-from, owner, service}` on every pod template. I can satisfy this for olake-ui / olake-worker / temporal / postgresql via their existing `podLabels` blocks, but the Fusion pod can't be reached without forking the chart.

## Changes

Same pattern `olake-ui/deployment.yaml` already uses:

```yaml
template:
  metadata:
    labels:
      app.kubernetes.io/name: ...
      ...
      {{- with .Values.fusion.podLabels }}
      {{- toYaml . | nindent 8 }}
      {{- end }}
    annotations:
      checksum/fusion-config: ...
      {{- with .Values.fusion.podAnnotations }}
      {{- toYaml . | nindent 8 }}
      {{- end }}
```

Defaults are `{}` in `values.yaml`, so existing deployments render byte-identically when neither value is set.

## Verification

```bash
# Default: unchanged labels/annotations
helm template test helm/olake --set fusion.enabled=true

# Overrides: both merged into the rendered deployment
helm template test helm/olake --set fusion.enabled=true \
  --set fusion.podLabels.foo=bar \
  --set fusion.podAnnotations.alpha=beta
```

Both render as expected — no other resources touched.

## Scope

Single template + matching values.yaml defaults. Mirrors existing conventions in this chart. No breaking change.