### PR TITLE
chore: bump up helm version

### DIFF
--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.18
-appVersion: "0.3.6"
+version: 0.0.19
+appVersion: "0.3.7"
 home: https://github.com/datazip-inc/olake-helm
 sources:
   - https://github.com/datazip-inc/olake-helm

--- a/index.html
+++ b/index.html
@@ -127,8 +127,8 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.18</p>
-                <p><strong>App Version:</strong> 0.3.6</p>
+                <p><strong>Version:</strong> 0.0.19</p>
+                <p><strong>App Version:</strong> 0.3.7</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">
                     <a href="https://github.com/datazip-inc/olake-helm/tree/master/helm/olake/README.md" target="_blank">📚 Documentation</a> |


### PR DESCRIPTION
Upgraded versions of :
- worker v0.3.6 -> v0.3.7 
- helm chart v0.0.18 -> v0.0.19