### PR TITLE
feat: update go version 1.25.11

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25.10-alpine AS builder
+FROM golang:1.25.11-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/worker/README.md
+++ b/worker/README.md
@@ -58,7 +58,7 @@ DevSpace provides a streamlined development workflow with live code sync, port f
 
 This will:
 - Deploy the OLake Helm chart to the cluster
-- Start a development container with Go 1.25.10
+- Start a development container with Go 1.25.11
 - Sync local code changes to the container in real-time
 - Forward port 8000 from olakeUI to `http://localhost:8000`
 - Open a terminal in the dev container
@@ -108,7 +108,7 @@ DevSpace is configured via `devspace.yaml` in this directory:
 - **Images**: Builds `olakego/k8s-worker` from local Dockerfile
 - **Deployments**: Uses the OLake Helm chart from `../../helm/olake`
 - **Dev Environment**: 
-  - Worker dev container with Go 1.25.10
+  - Worker dev container with Go 1.25.11
   - Live code sync from current directory
   - SSH access for IDE integration
 - **Port Forwarding**: 

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake-helm/worker
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/apache/spark-connect-go/v35 v35.0.0-20250317154112-ffd832059443


### PR DESCRIPTION
# Description

  Upgrades Go toolchain from `1.25.10` to `1.25.11` to patch 3 standard library vulnerabilities:

  - **GO-2026-5039** – Arbitrary inputs included in errors without escaping in `net/textproto`
  - **GO-2026-5038** – Quadratic complexity in `mime.WordDecoder.DecodeHeader`
  - **GO-2026-5037** – Inefficient candidate hostname parsing in `crypto/x509`

  Updated files: `worker/go.mod`, `worker/Dockerfile`, `worker/README.md`

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  # How Has This Been Tested?

  - [x] Backward compatibility — Go 1.25.11 is a patch release; no API or behavior changes
  - [x] `govulncheck ./...` passes clean after upgrade
  - [x] `go mod tidy` completed successfully

  # Screenshots or Recordings
  <!-- Attach related screenshots or recordings here -->

  ## Related PR's (If Any):