### PR TITLE
feat: add nfsServer.external.deletePVCOnUninstall for external shared PVC cleanup

### DIFF
--- a/helm/olake/templates/shared-storage-pvc.yaml
+++ b/helm/olake/templates/shared-storage-pvc.yaml
@@ -13,8 +13,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: shared-storage
     {{- include "olake.labels" . | nindent 4 }}
+  {{- if or .Values.nfsServer.enabled (not (.Values.nfsServer.external.deletePVCOnUninstall | default false)) }}
   annotations:
     "helm.sh/resource-policy": keep
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/helm/olake/templates/shared-storage-pvc.yaml
+++ b/helm/olake/templates/shared-storage-pvc.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: shared-storage
     {{- include "olake.labels" . | nindent 4 }}
-  {{- if or .Values.nfsServer.enabled (not (.Values.nfsServer.external.deletePVCOnUninstall | default false)) }}
+  {{- if or .Values.nfsServer.enabled (not .Values.nfsServer.external.deletePVCOnUninstall) }}
   annotations:
     "helm.sh/resource-policy": keep
   {{- end }}

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -330,6 +330,12 @@ nfsServer:
     # -- Size for the dynamically created external PVC
     size: "20Gi"
 
+    # -- Delete the external PVC on helm uninstall (opt-in; default false for backward compatibility)
+    # When false, the PVC keeps helm.sh/resource-policy: keep and persists after uninstall.
+    # When true and nfsServer.enabled is false, the keep policy is omitted so Helm deletes the PVC.
+    # Does not affect built-in NFS server PVCs.
+    deletePVCOnUninstall: false
+
   # -- Pod scheduling constraints
   nodeSelector: {}
 

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -330,10 +330,7 @@ nfsServer:
     # -- Size for the dynamically created external PVC
     size: "20Gi"
 
-    # -- Delete the external PVC on helm uninstall (opt-in; default false for backward compatibility)
-    # When false, the PVC keeps helm.sh/resource-policy: keep and persists after uninstall.
-    # When true and nfsServer.enabled is false, the keep policy is omitted so Helm deletes the PVC.
-    # Does not affect built-in NFS server PVCs.
+    # -- Delete the external PVC on helm uninstall
     deletePVCOnUninstall: false
 
   # -- Pod scheduling constraints


### PR DESCRIPTION
# Description

When `nfsServer.enabled: false` and an external StorageClass is used, the shared PVC (`olake-shared-storage`) always had `helm.sh/resource-policy: keep`, so it survived `helm uninstall` and blocked cleanup in environments that expect the volume to be removed with the release.

This PR adds an opt-in flag `nfsServer.external.deletePVCOnUninstall` (default `false`) so operators can omit the `keep` annotation and let Helm delete the external shared PVC on uninstall. Built-in NFS behavior is unchanged.

**Key changes:**
- **`values.yaml`**: New `nfsServer.external.deletePVCOnUninstall` (default `false`, backward compatible).
- **`templates/shared-storage-pvc.yaml`**: Apply `helm.sh/resource-policy: keep` only when built-in NFS is enabled, or external storage is used with `deletePVCOnUninstall: false`.

| `nfsServer.enabled` | `deletePVCOnUninstall` | `keep` on shared PVC | PVC after `helm uninstall` |
|---------------------|------------------------|----------------------|----------------------------|
| `false` | `false` (default) | Yes | Retained |
| `false` | `true` | No | Deleted by Helm |
| `true` | any | Yes | Unchanged (built-in NFS) |

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Manual verification on GKE with external StorageClass and `helm install` / `helm uninstall`:

| # | Scenario | Chart | `deletePVCOnUninstall` | After `helm uninstall` |
|---|----------|-------|------------------------|-------------------------|
| 1 | Current (published) | `olake/olake` | N/A | PVC remains |
| 2a | Upgrade (default) | published → PR | `false` | PVC remains |
| 2b | Upgrade (opt-in) | published → PR | `true` | PVC deleted |
| 3 | Fresh install | PR | `true` | PVC deleted |

# Screenshots or Recordings

N/A

## Related PR's (If Any):

N/A