### PR TITLE
feat: reduce probe initialDelaySeconds for faster startup

### DIFF
--- a/helm/olake/templates/olake-ui/deployment.yaml
+++ b/helm/olake/templates/olake-ui/deployment.yaml
@@ -175,7 +175,7 @@ spec:
         resources:
           {{- toYaml $resources | nindent 10 }}
         {{- $defaultReadinessProbe := dict 
-          "initialDelaySeconds" 30
+          "initialDelaySeconds" 5
           "periodSeconds" 10
           "timeoutSeconds" 5
           "failureThreshold" 3
@@ -186,7 +186,7 @@ spec:
         readinessProbe:
           {{- toYaml $readinessProbe | nindent 10 }}
         {{- $defaultLivenessProbe := dict 
-          "initialDelaySeconds" 60
+          "initialDelaySeconds" 10
           "periodSeconds" 30
           "timeoutSeconds" 10
           "failureThreshold" 3

--- a/helm/olake/templates/olake-worker/deployment.yaml
+++ b/helm/olake/templates/olake-worker/deployment.yaml
@@ -142,7 +142,7 @@ spec:
         resources:
           {{- toYaml $resources | nindent 10 }}
         {{- $defaultReadinessProbe := dict
-          "initialDelaySeconds" 30
+          "initialDelaySeconds" 5
           "periodSeconds" 10
           "timeoutSeconds" 5
           "failureThreshold" 3
@@ -153,7 +153,7 @@ spec:
         readinessProbe:
           {{- toYaml $readinessProbe | nindent 10 }}
         {{- $defaultLivenessProbe := dict
-          "initialDelaySeconds" 60
+          "initialDelaySeconds" 10
           "periodSeconds" 30
           "timeoutSeconds" 10
           "failureThreshold" 3


### PR DESCRIPTION
# Description

Reduce `initialDelaySeconds` on readiness and liveness probes for `olake-ui` and `olake-worker` to shorten stack startup time.

| Service | Readiness `initialDelaySeconds` | Liveness `initialDelaySeconds` |
|---------|--------------------------------|-------------------------------|
| olake-ui | 30 → 5 | 60 → 10 |
| olake-worker | 30 → 5 | 60 → 10 |

Fixes # internal issue

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manual `helm install` timing on GKE with external Temporal and external Postgres. Five runs with full namespace reset between runs.

| Run | Start (IST) | End (IST) | Duration (s) | `time` real |
| --- | --- | --- | --- | --- |
| 1 | 2026-06-05T15:43:53+05:30 | 2026-06-05T15:44:54+05:30 | 61 | 1:00.98 |
| 2 | 2026-06-05T15:45:45+05:30 | 2026-06-05T15:46:47+05:30 | 62 | 1:01.24 |
| 3 | 2026-06-05T15:47:40+05:30 | 2026-06-05T15:48:42+05:30 | 62 | 1:02.06 |
| 4 | 2026-06-05T15:50:22+05:30 | 2026-06-05T15:51:22+05:30 | 60 | 1:00.78 |
| 5 | 2026-06-05T15:53:42+05:30 | 2026-06-05T15:54:45+05:30 | 63 | 1:02.86 |


# Screenshots or Recordings

N/A

## Related PR's (If Any):

N/A