### PR TITLE
fix: added logging for pod-level failures

### DIFF
--- a/worker/executor/kubernetes/pod.go
+++ b/worker/executor/kubernetes/pod.go
@@ -66,6 +66,10 @@ func (k *KubernetesExecutor) waitForPodCompletion(ctx context.Context, podName s
 					containerInfo = fmt.Sprintf("exit code: %d, reason: %s", term.ExitCode, term.Reason)
 				}
 			}
+			// Fall back to pod-level reason/message for evictions and other pod-level failures
+			if containerInfo == "" {
+				containerInfo = fmt.Sprintf("reason: %s, message: %s", pod.Status.Reason, pod.Status.Message)
+			}
 			log.Error("pod failed", "podName", podName, "containerInfo", containerInfo)
 			return fmt.Errorf("%w: pod %s failed (%s)", constants.ErrExecutionFailed, podName, containerInfo)
 		}

--- a/worker/executor/kubernetes/pod.go
+++ b/worker/executor/kubernetes/pod.go
@@ -64,11 +64,14 @@ func (k *KubernetesExecutor) waitForPodCompletion(ctx context.Context, podName s
 				if status.State.Terminated != nil {
 					term := status.State.Terminated
 					containerInfo = fmt.Sprintf("exit code: %d, reason: %s", term.ExitCode, term.Reason)
+				} else {
+					// The only other two ContainerState options are Waiting and Running, so if it's not Terminated, it must be one of those
+					// refer: https://pkg.go.dev/k8s.io/api/core/v1#ContainerState
+					// Not expected as the pod is in Failed state with only one container, the container shouldnot be in Waiting or Running state, but logging for debugging purposes
+					containerInfo = fmt.Sprintf("container not terminated; reason: %s, message: %s", pod.Status.Reason, pod.Status.Message)
 				}
-			}
-			// Fall back to pod-level reason/message for evictions and other pod-level failures
-			if containerInfo == "" {
-				containerInfo = fmt.Sprintf("reason: %s, message: %s", pod.Status.Reason, pod.Status.Message)
+			} else {
+				containerInfo = fmt.Sprintf("containerStatus not found; reason: %s, message: %s", pod.Status.Reason, pod.Status.Message)
 			}
 			log.Error("pod failed", "podName", podName, "containerInfo", containerInfo)
 			return fmt.Errorf("%w: pod %s failed (%s)", constants.ErrExecutionFailed, podName, containerInfo)


### PR DESCRIPTION
# Description
When sync pods are evicted by the kubelet under **node memory pressure** (no container memory limit), the worker logged `pod failed` with an **empty `containerInfo`** and `failed ()`, making the failure hard to diagnose.
Root cause: `waitForPodCompletion` only read `ContainerStatuses[0].State.Terminated`. On node-level eviction, that field is often nil — the cause lives in `pod.Status.Reason` / `Message` (e.g. `Evicted`, memory pressure message).
This change falls back to pod-level reason and message when container termination info is absent. Normal container exits (exit 2, OOMKilled 137, etc.) are unchanged.
**Observed in issue (Job 17, Jun 8):**
```json
{"level":"error","podName":"sync-123-17-...","containerInfo":"","message":"pod failed"}
{"level":"error","podName":"sync-123-17-...","error":"execution failed: pod sync-123-17-... failed ()","message":"pod failed to complete"}
```

Fixes # adoption issue

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Not tested as the issue of empty containerInfo was not reproduced.


# Screenshots or Recordings
N/A

## Related PR's (If Any):
N/A