### PR TITLE
chore: staging -> master (worker v0.3.8, helm v0.0.20)

### DIFF
--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.19
-appVersion: "0.3.7"
+version: 0.0.20
+appVersion: "0.3.8"
 home: https://github.com/datazip-inc/olake-helm
 sources:
   - https://github.com/datazip-inc/olake-helm

--- a/helm/olake/templates/olake-ui/deployment.yaml
+++ b/helm/olake/templates/olake-ui/deployment.yaml
@@ -175,7 +175,7 @@ spec:
         resources:
           {{- toYaml $resources | nindent 10 }}
         {{- $defaultReadinessProbe := dict 
-          "initialDelaySeconds" 30
+          "initialDelaySeconds" 5
           "periodSeconds" 10
           "timeoutSeconds" 5
           "failureThreshold" 3
@@ -186,7 +186,7 @@ spec:
         readinessProbe:
           {{- toYaml $readinessProbe | nindent 10 }}
         {{- $defaultLivenessProbe := dict 
-          "initialDelaySeconds" 60
+          "initialDelaySeconds" 10
           "periodSeconds" 30
           "timeoutSeconds" 10
           "failureThreshold" 3

--- a/helm/olake/templates/olake-worker/deployment.yaml
+++ b/helm/olake/templates/olake-worker/deployment.yaml
@@ -142,7 +142,7 @@ spec:
         resources:
           {{- toYaml $resources | nindent 10 }}
         {{- $defaultReadinessProbe := dict
-          "initialDelaySeconds" 30
+          "initialDelaySeconds" 5
           "periodSeconds" 10
           "timeoutSeconds" 5
           "failureThreshold" 3
@@ -153,7 +153,7 @@ spec:
         readinessProbe:
           {{- toYaml $readinessProbe | nindent 10 }}
         {{- $defaultLivenessProbe := dict
-          "initialDelaySeconds" 60
+          "initialDelaySeconds" 10
           "periodSeconds" 30
           "timeoutSeconds" 10
           "failureThreshold" 3

--- a/helm/olake/templates/shared-storage-pvc.yaml
+++ b/helm/olake/templates/shared-storage-pvc.yaml
@@ -13,8 +13,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: shared-storage
     {{- include "olake.labels" . | nindent 4 }}
+  {{- if or .Values.nfsServer.enabled (not .Values.nfsServer.external.deletePVCOnUninstall) }}
   annotations:
     "helm.sh/resource-policy": keep
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -330,6 +330,9 @@ nfsServer:
     # -- Size for the dynamically created external PVC
     size: "20Gi"
 
+    # -- Delete the external PVC on helm uninstall
+    deletePVCOnUninstall: false
+
   # -- Pod scheduling constraints
   nodeSelector: {}
 

--- a/index.html
+++ b/index.html
@@ -127,8 +127,8 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.19</p>
-                <p><strong>App Version:</strong> 0.3.7</p>
+                <p><strong>Version:</strong> 0.0.20</p>
+                <p><strong>App Version:</strong> 0.3.8</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">
                     <a href="https://github.com/datazip-inc/olake-helm/tree/master/helm/olake/README.md" target="_blank">📚 Documentation</a> |

--- a/worker/executor/kubernetes/pod.go
+++ b/worker/executor/kubernetes/pod.go
@@ -64,7 +64,14 @@ func (k *KubernetesExecutor) waitForPodCompletion(ctx context.Context, podName s
 				if status.State.Terminated != nil {
 					term := status.State.Terminated
 					containerInfo = fmt.Sprintf("exit code: %d, reason: %s", term.ExitCode, term.Reason)
+				} else {
+					// The only other two ContainerState options are Waiting and Running, so if it's not Terminated, it must be one of those
+					// refer: https://pkg.go.dev/k8s.io/api/core/v1#ContainerState
+					// Not expected as the pod is in Failed state with only one container, the container shouldnot be in Waiting or Running state, but logging for debugging purposes
+					containerInfo = fmt.Sprintf("container not terminated; reason: %s, message: %s", pod.Status.Reason, pod.Status.Message)
 				}
+			} else {
+				containerInfo = fmt.Sprintf("containerStatus not found; reason: %s, message: %s", pod.Status.Reason, pod.Status.Message)
 			}
 			log.Error("pod failed", "podName", podName, "containerInfo", containerInfo)
 			return fmt.Errorf("%w: pod %s failed (%s)", constants.ErrExecutionFailed, podName, containerInfo)


### PR DESCRIPTION
Changes:
 - feat: add nfsServer.external.deletePVCOnUninstall for external shared PVC cleanup
 - feat: reduce initial probe delays for olake-ui and olake-worker
 - fix: added logging for pod-level failures
 - chore: worker v0.3.7 -> v0.3.8 and helm v0.0.19 -> v0.0.20