### PR TITLE
fix: fusion helm changes

### DIFF
--- a/helm/olake/templates/fusion/configmap.yaml
+++ b/helm/olake/templates/fusion/configmap.yaml
@@ -43,7 +43,7 @@ data:
             {{ printf "jdbc:postgresql://postgresql:5432/fusion" }}
           {{- else }}
             {{- $externalPg := .Values.postgresql.external.properties }}
-            {{ printf "jdbc:postgresql://%s:%s/%s" $externalPg.host $externalPg.port $externalPg.fusion_database }}
+            {{ printf "jdbc:postgresql://%s:%s/%s" $externalPg.host ($externalPg.port | toString) $externalPg.fusion_database }}
           {{- end }}
 
       terminal:

--- a/helm/olake/templates/fusion/deployment.yaml
+++ b/helm/olake/templates/fusion/deployment.yaml
@@ -335,13 +335,13 @@ spec:
             - name: "AMS_ADMIN__USERNAME"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "olake.fullname" . }}-fusion
-                  key: AdminUsername
+                  name: {{ .Values.olakeUI.initUser.existingSecret | default (printf "%s-fusion" (include "olake.fullname" .)) }}
+                  key: {{ if .Values.olakeUI.initUser.existingSecret }}{{ required "A username key must be provided in olakeUI.initUser.secretKeys" .Values.olakeUI.initUser.secretKeys.username }}{{ else }}AdminUsername{{ end }}
             - name: "AMS_ADMIN__PASSWORD"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "olake.fullname" . }}-fusion
-                  key: AdminPassword
+                  name: {{ .Values.olakeUI.initUser.existingSecret | default (printf "%s-fusion" (include "olake.fullname" .)) }}
+                  key: {{ if .Values.olakeUI.initUser.existingSecret }}{{ required "A password key must be provided in olakeUI.initUser.secretKeys" .Values.olakeUI.initUser.secretKeys.password }}{{ else }}AdminPassword{{ end }}
             - name: AMS_DATABASE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/helm/olake/templates/fusion/deployment.yaml
+++ b/helm/olake/templates/fusion/deployment.yaml
@@ -49,6 +49,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "olake.fusionServiceAccountName" . }}
       initContainers:
+      {{- if .Values.postgresql.enabled }}
       - name: create-fusion-database
         image: "{{ include "olake.registryBase" . }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
         imagePullPolicy: IfNotPresent
@@ -63,7 +64,6 @@ spec:
             done
             echo "PostgreSQL service is resolvable!"
 
-            # Wait for PostgreSQL to be ready (port check)
             echo "Waiting for PostgreSQL to be ready (port check)..."
             until nc -z "${POSTGRES_HOST}" "${POSTGRES_PORT}"; do
               echo "PostgreSQL port not ready yet. Waiting..."
@@ -72,8 +72,6 @@ spec:
             echo "PostgreSQL port is ready!"
 
             export PGPASSWORD=${POSTGRES_PASSWORD}
-            
-            {{- if .Values.postgresql.enabled }}
             echo "Attempting to create database 'fusion'..."
             if ! psql -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" -lqt | cut -d \| -f 1 | grep -qw "${POSTGRES_DATABASE}"; then
               psql -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" -d postgres -c "CREATE DATABASE ${POSTGRES_DATABASE}"
@@ -81,35 +79,33 @@ spec:
             else
               echo "Database '${POSTGRES_DATABASE}' already exists. Skipping creation."
             fi
-            {{- else }}
-            echo "External PostgreSQL is enabled, skipping database creation for 'fusion'."
-            {{- end }}
         env:
           - name: POSTGRES_HOST
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}host{{ else }}{{ .Values.postgresql.external.secretKeys.host }}{{ end }}
+                key: host
           - name: POSTGRES_PORT
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}port{{ else }}{{ .Values.postgresql.external.secretKeys.port }}{{ end }}
+                key: port
           - name: POSTGRES_USER
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}username{{ else }}{{ .Values.postgresql.external.secretKeys.username }}{{ end }}
+                key: username
           - name: POSTGRES_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}password{{ else }}{{ .Values.postgresql.external.secretKeys.password }}{{ end }}
+                key: password
           - name: POSTGRES_DATABASE
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}"fusion_database"{{ else }}{{ .Values.postgresql.external.secretKeys.fusion_database }}{{ end }}
+                key: fusion_database
+      {{- end }}
       - name: install-spark
         image: {{ include "olake.registryBase" . }}/{{ .Values.fusion.optimizer.spark.image.repository }}:{{ .Values.fusion.optimizer.spark.image.tag }}
         command: ["sh", "-c", "cp -r /opt/spark/* /target/"]

--- a/helm/olake/templates/fusion/secret.yaml
+++ b/helm/olake/templates/fusion/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.fusion.enabled }}
+{{- if and .Values.fusion.enabled (not .Values.olakeUI.initUser.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/component: fusion
 type: Opaque
 data:
-  AdminUsername: {{ (.Values.fusion.adminUser | default "admin") | b64enc | quote }}
-  AdminPassword: {{ (.Values.fusion.adminPassword | default "password") | b64enc | quote }}
+  AdminUsername: {{ .Values.olakeUI.initUser.adminUser.username | b64enc | quote }}
+  AdminPassword: {{ .Values.olakeUI.initUser.adminUser.password | b64enc | quote }}
 {{- end }}

--- a/helm/olake/templates/olake-ui/deployment.yaml
+++ b/helm/olake/templates/olake-ui/deployment.yaml
@@ -114,9 +114,15 @@ spec:
         - name: OPTIMIZATION_GROUP
           value: spark-container
         - name: USERNAME
-          value: {{ .Values.fusion.adminUser | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.olakeUI.initUser.existingSecret | default (printf "%s-fusion" (include "olake.fullname" .)) }}
+              key: {{ if .Values.olakeUI.initUser.existingSecret }}{{ required "A username key must be provided in olakeUI.initUser.secretKeys" .Values.olakeUI.initUser.secretKeys.username }}{{ else }}AdminUsername{{ end }}
         - name: PASSWORD
-          value: {{ .Values.fusion.adminPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.olakeUI.initUser.existingSecret | default (printf "%s-fusion" (include "olake.fullname" .)) }}
+              key: {{ if .Values.olakeUI.initUser.existingSecret }}{{ required "A password key must be provided in olakeUI.initUser.secretKeys" .Values.olakeUI.initUser.secretKeys.password }}{{ else }}AdminPassword{{ end }}
         {{- end }}
         # Database configuration
         - name: OLAKE_POSTGRES_HOST

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -217,6 +217,8 @@ olakeUI:
 
     # -- Credentials for the initial admin user.
     # These values are used only if `existingSecret` is not provided.
+    # When Fusion is enabled, the same credentials are used for the Fusion UI
+    # and the Fusion optimizer bootstrap job.
     adminUser:
       # -- Admin username
       username: "admin"
@@ -615,13 +617,6 @@ fusion:
   # -- Enable Fusion (Amoro) components.
   # Set to false to disable all Fusion resources.
   enabled: false
-
-  # --- Fusion admin credentials
-  # These credentials are used for:
-  # - Logging into the Fusion UI
-  # - Running the Fusion init job that creates the optimizer group
-  adminUser: admin
-  adminPassword: password
 
   # -- Service Account configuration
   serviceAccount:


### PR DESCRIPTION
# Description

Fusion helm chart improvements for credential management, external Postgres compatibility and init container cleanup.

**Changes:**
- Remove `fusion.adminUser` / `fusion.adminPassword` — Fusion and olake-ui now use `olakeUI.initUser` credentials (or `existingSecret`) as the single source of truth
- Fix Fusion JDBC URL for external Postgres by coercing `port` with `toString` (fixes `%!s(float64=5432)` rendering failure)
- Skip `create-fusion-database` init container when using external Postgres (no longer pulls bundled Postgres image for a connectivity-only check)

Fixes  minor bugs and optimizations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (needs rollout restart of ui for upgrading users after the fusion pods restarts; this is for **Signature check failure**)
- [x] This change requires a documentation update (need to remove the customization for admin in fusion helm if there)

# How Has This Been Tested?

- [x] Fresh install with Fusion enabled — default credentials, catalogs/tables list in Maintenance
- [x] Upgrade from stable chart with custom `fusion.adminUser` / `fusion.adminPassword` — verified credential migration path to `olakeUI.initUser`
- [x] External Postgres with numeric `port: 5432` — Fusion JDBC URL renders correctly, pod reaches Running
- [x] External Postgres — `create-fusion-database` init container not deployed; bundled Postgres still creates `fusion` DB when `postgresql.enabled: true`
- [x] `helm template` sanity checks for JDBC URL, init container presence and credential secret refs

# Screenshots or Recordings
<!-- N/A -->

## Related PR's (If Any):
<!-- N/A -->