### PR TITLE
chore: staging -> master (olake-helm v0.0.21, olake-worker 0.3.9)

### DIFF
--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.20
-appVersion: "0.3.8"
+version: 0.0.21
+appVersion: "0.3.9"
 home: https://github.com/datazip-inc/olake-helm
 sources:
   - https://github.com/datazip-inc/olake-helm

--- a/helm/olake/README.md
+++ b/helm/olake/README.md
@@ -342,28 +342,54 @@ global:
 
 ### Private Container Registry
 
-For deployments in air-gapped environments or clusters without access to public registries (Docker Hub, registry.k8s.io), all container images can be pulled from a private registry by setting `CONTAINER_REGISTRY_BASE` in `global.env`:
+OLake supports pulling all images from a private or self-hosted container registry.
+
+#### Step 1 — Point OLake at the registry
+
+Setting `CONTAINER_REGISTRY_BASE` in `global.env` causes every image reference in the chart to be automatically prefixed with that value — no per-image overrides are needed.
 
 ```yaml
 global:
   env:
-    CONTAINER_REGISTRY_BASE: "1234567890123.dkr.ecr.us-east-1.amazonaws.com/dockerhub_mirror"
+    CONTAINER_REGISTRY_BASE: "registry.example.com/myproject"
 ```
 
-When set, **all** container images are automatically prefixed with this registry base — no additional `image.repository` overrides are needed. If left unset, images are pulled from Docker Hub (`registry-1.docker.io`) by default.
+The following images must be mirrored to the registry before deploying:
 
-**Note:** Ensure the following images are mirrored to your private registry (`CONTAINER_REGISTRY_BASE/...`) before deploying:
-- `library/busybox:latest`
-- `curlimages/curl:8.1.2`
-- `olakego/ui:latest`, `olakego/ui-worker:latest`
-- `olakego/source-*` (connector images, example `1234567890123.dkr.ecr.us-east-1.amazonaws.com/dockerhub_mirror/olakego/source-mysql:v0.4.0`)
-- `temporalio/auto-setup:1.22.3`, `temporalio/ui:2.16.2`
-- `library/postgres:14-alpine`
-- `sig-storage/nfs-provisioner:v4.0.8` (built-in NFS server; sourced from `registry.k8s.io`, not Docker Hub)
+| Image | Source |
+|---|---|
+| `library/busybox:latest` | Docker Hub |
+| `curlimages/curl:8.1.2` | Docker Hub |
+| `olakego/ui:latest`, `olakego/ui-worker:latest` | Docker Hub |
+| `olakego/source-*` (e.g. `olakego/source-mongodb:v0.7.0`) | Docker Hub |
+| `temporalio/auto-setup:1.22.3`, `temporalio/ui:2.16.2` | Docker Hub |
+| `library/postgres:14-alpine` | Docker Hub |
+| `olakego/fusion:latest`, `olakego/fusion-spark:latest` | Docker Hub |
+| `sig-storage/nfs-provisioner:v4.0.8` | `registry.k8s.io` (built-in NFS only) |
 
-> **Warning:** When using a private container registry (e.g., Amazon ECR, Google Artifact Registry, Azure ACR), the `olake-ui` pod requires permissions to list repositories and image tags in order to discover available source connectors. To grant access, either:
-> - Pass registry credentials as environment variables under `olakeUI.env` (e.g., `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` for ECR), or
-> - Attach the required read-only registry permissions to the IAM role referenced by `global.jobServiceAccount`.
+#### Step 2 — Authenticate with the registry
+
+If the registry requires credentials, a Kubernetes docker-registry secret must be created:
+
+```bash
+kubectl create secret docker-registry my-registry-secret \
+  --docker-server=registry.example.com \
+  --docker-username=<username> \
+  --docker-password=<password>
+```
+
+The secret is then referenced in `values.yaml`:
+
+```yaml
+global:
+  imagePullSecrets:
+    - name: my-registry-secret
+
+  env:
+    CONTAINER_REGISTRY_BASE: "registry.example.com/myproject"
+```
+
+> **Note:** For cloud-managed registries (Amazon ECR, Google Artifact Registry, Azure ACR), IAM-based authentication (IRSA / Workload Identity) is preferred over static credentials. See [Cloud IAM Integration](#cloud-iam-integration).
 
 ## Monitoring and Troubleshooting
 

--- a/helm/olake/templates/fusion/configmap.yaml
+++ b/helm/olake/templates/fusion/configmap.yaml
@@ -43,7 +43,7 @@ data:
             {{ printf "jdbc:postgresql://postgresql:5432/fusion" }}
           {{- else }}
             {{- $externalPg := .Values.postgresql.external.properties }}
-            {{ printf "jdbc:postgresql://%s:%s/%s" $externalPg.host $externalPg.port $externalPg.fusion_database }}
+            {{ printf "jdbc:postgresql://%s:%s/%s" $externalPg.host ($externalPg.port | toString) $externalPg.fusion_database }}
           {{- end }}
 
       terminal:

--- a/helm/olake/templates/fusion/deployment.yaml
+++ b/helm/olake/templates/fusion/deployment.yaml
@@ -49,6 +49,7 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "olake.fusionServiceAccountName" . }}
       initContainers:
+      {{- if .Values.postgresql.enabled }}
       - name: create-fusion-database
         image: "{{ include "olake.registryBase" . }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
         imagePullPolicy: IfNotPresent
@@ -63,7 +64,6 @@ spec:
             done
             echo "PostgreSQL service is resolvable!"
 
-            # Wait for PostgreSQL to be ready (port check)
             echo "Waiting for PostgreSQL to be ready (port check)..."
             until nc -z "${POSTGRES_HOST}" "${POSTGRES_PORT}"; do
               echo "PostgreSQL port not ready yet. Waiting..."
@@ -72,8 +72,6 @@ spec:
             echo "PostgreSQL port is ready!"
 
             export PGPASSWORD=${POSTGRES_PASSWORD}
-            
-            {{- if .Values.postgresql.enabled }}
             echo "Attempting to create database 'fusion'..."
             if ! psql -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" -lqt | cut -d \| -f 1 | grep -qw "${POSTGRES_DATABASE}"; then
               psql -h "${POSTGRES_HOST}" -p "${POSTGRES_PORT}" -U "${POSTGRES_USER}" -d postgres -c "CREATE DATABASE ${POSTGRES_DATABASE}"
@@ -81,35 +79,33 @@ spec:
             else
               echo "Database '${POSTGRES_DATABASE}' already exists. Skipping creation."
             fi
-            {{- else }}
-            echo "External PostgreSQL is enabled, skipping database creation for 'fusion'."
-            {{- end }}
         env:
           - name: POSTGRES_HOST
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}host{{ else }}{{ .Values.postgresql.external.secretKeys.host }}{{ end }}
+                key: host
           - name: POSTGRES_PORT
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}port{{ else }}{{ .Values.postgresql.external.secretKeys.port }}{{ end }}
+                key: port
           - name: POSTGRES_USER
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}username{{ else }}{{ .Values.postgresql.external.secretKeys.username }}{{ end }}
+                key: username
           - name: POSTGRES_PASSWORD
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}password{{ else }}{{ .Values.postgresql.external.secretKeys.password }}{{ end }}
+                key: password
           - name: POSTGRES_DATABASE
             valueFrom:
               secretKeyRef:
                 name: {{ include "olake.postgresql.secretName" . }}
-                key: {{ if .Values.postgresql.enabled }}"fusion_database"{{ else }}{{ .Values.postgresql.external.secretKeys.fusion_database }}{{ end }}
+                key: fusion_database
+      {{- end }}
       - name: install-spark
         image: {{ include "olake.registryBase" . }}/{{ .Values.fusion.optimizer.spark.image.repository }}:{{ .Values.fusion.optimizer.spark.image.tag }}
         command: ["sh", "-c", "cp -r /opt/spark/* /target/"]
@@ -335,13 +331,13 @@ spec:
             - name: "AMS_ADMIN__USERNAME"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "olake.fullname" . }}-fusion
-                  key: AdminUsername
+                  name: {{ .Values.olakeUI.initUser.existingSecret | default (printf "%s-fusion" (include "olake.fullname" .)) }}
+                  key: {{ if .Values.olakeUI.initUser.existingSecret }}{{ required "A username key must be provided in olakeUI.initUser.secretKeys" .Values.olakeUI.initUser.secretKeys.username }}{{ else }}AdminUsername{{ end }}
             - name: "AMS_ADMIN__PASSWORD"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "olake.fullname" . }}-fusion
-                  key: AdminPassword
+                  name: {{ .Values.olakeUI.initUser.existingSecret | default (printf "%s-fusion" (include "olake.fullname" .)) }}
+                  key: {{ if .Values.olakeUI.initUser.existingSecret }}{{ required "A password key must be provided in olakeUI.initUser.secretKeys" .Values.olakeUI.initUser.secretKeys.password }}{{ else }}AdminPassword{{ end }}
             - name: AMS_DATABASE_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/helm/olake/templates/fusion/secret.yaml
+++ b/helm/olake/templates/fusion/secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.fusion.enabled }}
+{{- if and .Values.fusion.enabled (not .Values.olakeUI.initUser.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/component: fusion
 type: Opaque
 data:
-  AdminUsername: {{ (.Values.fusion.adminUser | default "admin") | b64enc | quote }}
-  AdminPassword: {{ (.Values.fusion.adminPassword | default "password") | b64enc | quote }}
+  AdminUsername: {{ .Values.olakeUI.initUser.adminUser.username | b64enc | quote }}
+  AdminPassword: {{ .Values.olakeUI.initUser.adminUser.password | b64enc | quote }}
 {{- end }}

--- a/helm/olake/templates/fusion/serviceaccount.yaml
+++ b/helm/olake/templates/fusion/serviceaccount.yaml
@@ -21,5 +21,9 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/olake/templates/olake-ui/deployment.yaml
+++ b/helm/olake/templates/olake-ui/deployment.yaml
@@ -97,6 +97,10 @@ spec:
         env:
         - name: PERSISTENT_DIR
           value: "/tmp/olake-config"
+        {{- with index .Values.global.imagePullSecrets 0 }}
+        - name: DOCKER_CONFIG
+          value: /etc/olake/registry
+        {{- end }}
         {{- range $key, $value := .Values.global.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}
@@ -173,6 +177,11 @@ spec:
           mountPath: /app/olake-ui/conf
         - name: shared-storage
           mountPath: /tmp/olake-config
+        {{- with index .Values.global.imagePullSecrets 0 }}
+        - name: registry-creds
+          mountPath: /etc/olake/registry
+          readOnly: true
+        {{- end }}
         {{- $defaultResources := dict 
           "requests" (dict "memory" "512Mi" "cpu" "500m")
         }}
@@ -209,3 +218,11 @@ spec:
       - name: shared-storage
         persistentVolumeClaim:
           claimName: {{ include "olake.sharedStoragePVC" . }}
+      {{- with index .Values.global.imagePullSecrets 0 }}
+      - name: registry-creds
+        secret:
+          secretName: {{ .name }}
+          items:
+            - key: .dockerconfigjson
+              path: config.json
+      {{- end }}

--- a/helm/olake/templates/olake-ui/deployment.yaml
+++ b/helm/olake/templates/olake-ui/deployment.yaml
@@ -114,9 +114,15 @@ spec:
         - name: OPTIMIZATION_GROUP
           value: spark-container
         - name: USERNAME
-          value: {{ .Values.fusion.adminUser | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.olakeUI.initUser.existingSecret | default (printf "%s-fusion" (include "olake.fullname" .)) }}
+              key: {{ if .Values.olakeUI.initUser.existingSecret }}{{ required "A username key must be provided in olakeUI.initUser.secretKeys" .Values.olakeUI.initUser.secretKeys.username }}{{ else }}AdminUsername{{ end }}
         - name: PASSWORD
-          value: {{ .Values.fusion.adminPassword | quote }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.olakeUI.initUser.existingSecret | default (printf "%s-fusion" (include "olake.fullname" .)) }}
+              key: {{ if .Values.olakeUI.initUser.existingSecret }}{{ required "A password key must be provided in olakeUI.initUser.secretKeys" .Values.olakeUI.initUser.secretKeys.password }}{{ else }}AdminPassword{{ end }}
         {{- end }}
         # Database configuration
         - name: OLAKE_POSTGRES_HOST

--- a/helm/olake/templates/olake-ui/init-user.yaml
+++ b/helm/olake/templates/olake-ui/init-user.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/component: init
     spec:
       restartPolicy: Never
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
       - name: wait-for-olake-ui
         image: "{{ include "olake.registryBase" . }}/library/busybox:latest"

--- a/helm/olake/templates/olake-worker/job-serviceaccount.yaml
+++ b/helm/olake/templates/olake-worker/job-serviceaccount.yaml
@@ -12,4 +12,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: true
+{{- with .Values.global.imagePullSecrets }}
+# Pods created by olake-workers (connector test/discover/sync jobs) run under this
+# ServiceAccount, so attaching the pull secrets here lets the kubelet authenticate
+# pulls from a private registry (Harbor, Nexus, etc.) without per-pod configuration.
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/helm/olake/templates/post-install-wait.yaml
+++ b/helm/olake/templates/post-install-wait.yaml
@@ -21,6 +21,10 @@ spec:
         app.kubernetes.io/component: post-install-wait
     spec:
       restartPolicy: Never
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: wait-for-stack
         image: "{{ include "olake.registryBase" . }}/curlimages/curl:8.1.2"

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -19,7 +19,11 @@ global:
   storageClass: ""
 
   # -- Global image pull secrets for private container registries
-  # List of Kubernetes secret names containing registry credentials
+  # List of Kubernetes secret names containing registry credentials.
+  # Applied to all long-running Deployments AND to the connector job pods spawned
+  # by olake-workers (via the job ServiceAccount), so private connector images
+  # (Harbor, Nexus, Quay, etc.) can be pulled during test/discover/sync.
+  # To cover connector job pods, also set `global.jobServiceAccount.create: true`.
   # NOTE: Secrets must be created separately using kubectl or other means
   # Examples:
   #   Create secret: kubectl create secret docker-registry my-registry-secret \

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -217,6 +217,8 @@ olakeUI:
 
     # -- Credentials for the initial admin user.
     # These values are used only if `existingSecret` is not provided.
+    # When Fusion is enabled, the same credentials are used for the Fusion UI
+    # and the Fusion optimizer bootstrap job.
     adminUser:
       # -- Admin username
       username: "admin"
@@ -615,13 +617,6 @@ fusion:
   # -- Enable Fusion (Amoro) components.
   # Set to false to disable all Fusion resources.
   enabled: false
-
-  # --- Fusion admin credentials
-  # These credentials are used for:
-  # - Logging into the Fusion UI
-  # - Running the Fusion init job that creates the optimizer group
-  adminUser: admin
-  adminPassword: password
 
   # -- Service Account configuration
   serviceAccount:

--- a/index.html
+++ b/index.html
@@ -127,8 +127,8 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.20</p>
-                <p><strong>App Version:</strong> 0.3.8</p>
+                <p><strong>Version:</strong> 0.0.21</p>
+                <p><strong>App Version:</strong> 0.3.9</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">
                     <a href="https://github.com/datazip-inc/olake-helm/tree/master/helm/olake/README.md" target="_blank">📚 Documentation</a> |

--- a/worker/constants/env.go
+++ b/worker/constants/env.go
@@ -25,6 +25,11 @@ const (
 
 	// registry
 	ContainerRegistryBase = "CONTAINER_REGISTRY_BASE"
+	// Optional credentials for a generic private registry (Harbor, Nexus, Quay, GitLab,
+	// registry:2). Used to authenticate Docker-mode image pulls without `docker login`.
+	// Left empty for Docker Hub or for ECR/GCR (which authenticate via cloud IAM / host creds).
+	EnvRegistryUsername = "CONTAINER_REGISTRY_USERNAME"
+	EnvRegistryPassword = "CONTAINER_REGISTRY_PASSWORD"
 
 	// worker
 	EnvLogRetentionPeriod = "LOG_RETENTION_PERIOD"

--- a/worker/executor/docker/container.go
+++ b/worker/executor/docker/container.go
@@ -3,6 +3,8 @@ package docker
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +18,9 @@ import (
 	"github.com/datazip-inc/olake-helm/worker/utils/logger"
 	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/registry"
 	"github.com/moby/moby/client"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -38,7 +42,7 @@ func (d *DockerExecutor) PullImage(ctx context.Context, imageName, version strin
 
 		// Image doesn't exist, pull it
 		log.Info("image not found locally, pulling", "image", imageName)
-		reader, err := d.client.ImagePull(pullCtx, imageName, client.ImagePullOptions{})
+		reader, err := d.client.ImagePull(pullCtx, imageName, client.ImagePullOptions{RegistryAuth: registryAuth()})
 		if err != nil {
 			if errors.Is(pullCtx.Err(), context.DeadlineExceeded) {
 				log.Error("image pull timed out", "image", imageName)
@@ -158,6 +162,29 @@ func (d *DockerExecutor) StopContainer(ctx context.Context, workflowID string) e
 
 	log.Info("container removed successfully", "workflowID", workflowID, "containerName", containerName)
 	return nil
+}
+
+// registryAuth returns the base64url-encoded registry credentials for image pulls,
+// built from CONTAINER_REGISTRY_USERNAME/PASSWORD. When unset it returns "", so the
+// Docker daemon falls back to its own credential store (host `docker login` / IAM) -
+// preserving existing behavior for Docker Hub, ECR, and GCR.
+func registryAuth() string {
+	username := strings.TrimSpace(viper.GetString(constants.EnvRegistryUsername))
+	password := strings.TrimSpace(viper.GetString(constants.EnvRegistryPassword))
+	if username == "" && password == "" {
+		return ""
+	}
+
+	authConfig := registry.AuthConfig{
+		Username:      username,
+		Password:      password,
+		ServerAddress: strings.TrimSpace(viper.GetString(constants.ContainerRegistryBase)),
+	}
+	encoded, err := json.Marshal(authConfig)
+	if err != nil {
+		return ""
+	}
+	return base64.URLEncoding.EncodeToString(encoded)
 }
 
 func (d *DockerExecutor) startContainer(ctx context.Context, containerID string) error {


### PR DESCRIPTION
# Description
- Add CONTAINER_REGISTRY_USERNAME/PASSWORD env constants for genericprivate registry credentials 
- Pass base64-encoded registry auth to Docker ImagePull via new registryAuth() helper; falls back to daemon credential store when
  env vars are unset (preserving behavior for Docker Hub, ECR, GCR)
- Attach imagePullSecrets from global.imagePullSecrets to the worker job ServiceAccount so connector job pods can pull private images without per-pod configuration
- Update values.yaml comments to clarify pull-secret propagation to connector test/discover/sync job pods
- Remove fusion.adminUser / fusion.adminPassword — Fusion and olake-ui now use olakeUI.initUser credentials (or existingSecret) as the single source of truth
- Fix Fusion JDBC URL for external Postgres by coercing port with toString (fixes %!s(float64=5432) rendering failure)
Skip create-fusion-database init container when using external Postgres (no longer pulls bundled Postgres image for a connectivity-only check)

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
