### PR TITLE
chore: staging -> master (olake-helm v0.0.22)

### DIFF
--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.21
+version: 0.0.22
 appVersion: "0.3.9"
 home: https://github.com/datazip-inc/olake-helm
 sources:

--- a/helm/olake/templates/fusion/deployment.yaml
+++ b/helm/olake/templates/fusion/deployment.yaml
@@ -24,8 +24,14 @@ spec:
         app.kubernetes.io/name: {{ include "olake.name" . }}-fusion
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: fusion
+        {{- with .Values.fusion.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         checksum/fusion-config: {{ include (print $.Template.BasePath "/fusion/configmap.yaml") . | sha256sum }}
+        {{- with .Values.fusion.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.fusion.nodeSelector }}
       nodeSelector:

--- a/helm/olake/templates/olake-ui/deployment.yaml
+++ b/helm/olake/templates/olake-ui/deployment.yaml
@@ -97,7 +97,7 @@ spec:
         env:
         - name: PERSISTENT_DIR
           value: "/tmp/olake-config"
-        {{- with index .Values.global.imagePullSecrets 0 }}
+        {{- with first .Values.global.imagePullSecrets }}
         - name: DOCKER_CONFIG
           value: /etc/olake/registry
         {{- end }}
@@ -177,7 +177,7 @@ spec:
           mountPath: /app/olake-ui/conf
         - name: shared-storage
           mountPath: /tmp/olake-config
-        {{- with index .Values.global.imagePullSecrets 0 }}
+        {{- with first .Values.global.imagePullSecrets }}
         - name: registry-creds
           mountPath: /etc/olake/registry
           readOnly: true
@@ -218,7 +218,7 @@ spec:
       - name: shared-storage
         persistentVolumeClaim:
           claimName: {{ include "olake.sharedStoragePVC" . }}
-      {{- with index .Values.global.imagePullSecrets 0 }}
+      {{- with first .Values.global.imagePullSecrets }}
       - name: registry-creds
         secret:
           secretName: {{ .name }}

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -670,7 +670,13 @@ fusion:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  
+
+  # -- Additional pod annotations
+  podAnnotations: {}
+
+  # -- Additional pod labels
+  podLabels: {}
+
   # --- Amoro config shade properties
   shade:
     identifier: "default"

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.21</p>
+                <p><strong>Version:</strong> 0.0.22</p>
                 <p><strong>App Version:</strong> 0.3.9</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">


### PR DESCRIPTION
# Description

Fixes a template panic introduced in 0.0.21 that occurs when `global.imagePullSecrets` is empty (the default). `index .Values.global.imagePullSecrets 0` is evaluated eagerly by the Go template engine before the `with` guard can protect it, causing `helm upgrade` to fail with:

```
error calling index: reflect: slice index out of range
```

Replaced all three occurrences in `olake-ui/deployment.yaml` with `first .Values.global.imagePullSecrets`, which returns nil for empty lists and allows `with` to safely skip the block.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] **Scenario A — Upgrade (existing user, no private registry):** Installed published `0.0.20` without `imagePullSecrets`, then upgraded to `0.0.22` using the local chart with no `imagePullSecrets` set. Upgrade succeeded, all pods came up healthy.
- [x] **Scenario B — Fresh install with private registry (Harbor):** Installed `0.0.22` with `global.imagePullSecrets` pointing to a Harbor registry. All pods pulled images from Harbor successfully, including fusion, NFS server, and connector jobs.

# Screenshots or Recordings

N/A

## Related PR's (If Any):

Follows #165 (feat: support private registry auth)