### PR TITLE
feat: add global.podAnnotations and inject imagePullSecrets into pods

### DIFF
--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.23
-appVersion: "0.3.10"
+version: 0.0.24
+appVersion: "0.3.11"
 home: https://github.com/datazip-inc/olake-helm
 sources:
   - https://github.com/datazip-inc/olake-helm

--- a/helm/olake/templates/olake-worker/configmap.yaml
+++ b/helm/olake/templates/olake-worker/configmap.yaml
@@ -60,3 +60,10 @@ data:
   {{- if .Values.global.podAnnotations }}
   OLAKE_JOB_POD_ANNOTATIONS: {{ .Values.global.podAnnotations | toJson | quote }}
   {{- end }}
+
+  # =================================================================
+  # ACTIVITY POD IMAGE PULL SECRETS CONFIGURATION
+  # =================================================================
+  {{- if .Values.global.imagePullSecrets }}
+  OLAKE_JOB_IMAGE_PULL_SECRETS: {{ .Values.global.imagePullSecrets | toJson | quote }}
+  {{- end }}

--- a/helm/olake/templates/olake-worker/job-serviceaccount.yaml
+++ b/helm/olake/templates/olake-worker/job-serviceaccount.yaml
@@ -12,11 +12,4 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: true
-{{- with .Values.global.imagePullSecrets }}
-# Pods created by olake-workers (connector test/discover/sync jobs) run under this
-# ServiceAccount, so attaching the pull secrets here lets the kubelet authenticate
-# pulls from a private registry (Harbor, Nexus, etc.) without per-pod configuration.
-imagePullSecrets:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
 {{- end }}

--- a/index.html
+++ b/index.html
@@ -127,8 +127,8 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.23</p>
-                <p><strong>App Version:</strong> 0.3.10</p>
+                <p><strong>Version:</strong> 0.0.24</p>
+                <p><strong>App Version:</strong> 0.3.11</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">
                     <a href="https://github.com/datazip-inc/olake-helm/tree/master/helm/olake/README.md" target="_blank">📚 Documentation</a> |

--- a/worker/constants/env.go
+++ b/worker/constants/env.go
@@ -58,4 +58,7 @@ const (
 
 	// activity pod annotations
 	EnvJobPodAnnotations = "OLAKE_JOB_POD_ANNOTATIONS"
+
+	// activity pod image pull secrets
+	EnvJobImagePullSecrets = "OLAKE_JOB_IMAGE_PULL_SECRETS"
 )

--- a/worker/executor/kubernetes/executor.go
+++ b/worker/executor/kubernetes/executor.go
@@ -30,15 +30,16 @@ type KubernetesExecutor struct {
 }
 
 type KubernetesConfig struct {
-	Namespace          string
-	PVCName            string
-	ServiceAccount     string
-	JobServiceAccount  string
-	SecretKey          string
-	BasePath           string
-	WorkerIdentity     string
-	SecurityContext    *corev1.PodSecurityContext
-	JobPodAnnotations  map[string]string
+	Namespace            string
+	PVCName              string
+	ServiceAccount       string
+	JobServiceAccount    string
+	SecretKey            string
+	BasePath             string
+	WorkerIdentity       string
+	SecurityContext      *corev1.PodSecurityContext
+	JobPodAnnotations    map[string]string
+	JobImagePullSecrets  []corev1.LocalObjectReference
 }
 
 func NewKubernetesExecutor(ctx context.Context) (*KubernetesExecutor, error) {
@@ -89,6 +90,16 @@ func NewKubernetesExecutor(ctx context.Context) (*KubernetesExecutor, error) {
 		}
 	}
 
+	// Parse job image pull secrets JSON if available
+	var jobImagePullSecrets []corev1.LocalObjectReference
+	jobImagePullSecretsJSON := viper.GetString(constants.EnvJobImagePullSecrets)
+	if jobImagePullSecretsJSON != "" {
+		if err := json.Unmarshal([]byte(jobImagePullSecretsJSON), &jobImagePullSecrets); err != nil {
+			logger.Errorf("failed to unmarshal job image pull secrets: %s. using default.", err)
+			jobImagePullSecrets = nil
+		}
+	}
+
 	// Set worker identity
 	podName := viper.GetString(constants.EnvPodName)
 	workerIdenttity := fmt.Sprintf("olake.io/olake-workers/%s", podName)
@@ -110,8 +121,9 @@ func NewKubernetesExecutor(ctx context.Context) (*KubernetesExecutor, error) {
 			SecretKey:         secretKey,
 			BasePath:          basePath,
 			WorkerIdentity:    workerIdenttity,
-			SecurityContext:   securityContext,
-			JobPodAnnotations: jobPodAnnotations,
+			SecurityContext:     securityContext,
+			JobPodAnnotations:   jobPodAnnotations,
+			JobImagePullSecrets: jobImagePullSecrets,
 		},
 	}, nil
 }

--- a/worker/executor/kubernetes/pod.go
+++ b/worker/executor/kubernetes/pod.go
@@ -239,6 +239,10 @@ func (k *KubernetesExecutor) CreatePodSpec(req *types.ExecutionRequest, workDir,
 		pod.Spec.ServiceAccountName = k.config.JobServiceAccount
 	}
 
+	if len(k.config.JobImagePullSecrets) > 0 {
+		pod.Spec.ImagePullSecrets = k.config.JobImagePullSecrets
+	}
+
 	// Add liveness probe for long-running sync operations
 	if slices.Contains(constants.AsyncCommands, req.Command) {
 		pod.Spec.Containers[0].LivenessProbe = &corev1.Probe{


### PR DESCRIPTION
## Description

Removes `imagePullSecrets` from the job service account and instead injects them directly into activity pod specs via the worker. This is cleaner and avoids confusion — the job SA was the only reason imagePullSecrets were on it, and that coupling was non-obvious.

The worker now reads two new env vars from the configmap:
- `OLAKE_JOB_IMAGE_PULL_SECRETS` — JSON array of pull secret refs, set directly on `pod.Spec.ImagePullSecrets`
- `OLAKE_JOB_POD_ANNOTATIONS` — JSON map merged with internal `olake.io/*` annotations (internal keys always win)

Fully backward compatible — new worker handles absent env vars gracefully (old chart clients unaffected).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Scenario 1 — Fresh install (chart 0.0.24, worker 0.3.11, Harbor): activity pod gets `harbor-secret` + custom annotation
- [x] Scenario 2 — Empty `imagePullSecrets: []`: no panic, activity pod has no pull secrets 
- [x] Scenario 3 — Upgrade 0.0.22 → 0.0.24: configmap updated, new worker picks up new env vars 
- [x] Scenario 4 — New chart + old worker (v0.3.10): old worker ignores unknown env vars, no crash; upgrading worker alone enables features 
- [x] Scenario 5 — Old chart (0.0.22) + new worker (0.3.11): worker starts cleanly with absent env vars, no regression for existing clients 
