### PR TITLE
chore: staging -> master (olake-helm v0.0.24)

### DIFF
--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.23
+version: 0.0.24
 appVersion: "0.3.10"
 home: https://github.com/datazip-inc/olake-helm
 sources:

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -78,7 +78,7 @@ global:
   # -- Service account configuration for job pods created by olake-workers
   # Used for cloud provider IAM integration (AWS IRSA, GCP Workload Identity, Azure Workload Identity)
   jobServiceAccount:
-    create: false
+    create: true
     name: ""
 
     # Used for cloud provider IAM role association

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.23</p>
+                <p><strong>Version:</strong> 0.0.24</p>
                 <p><strong>App Version:</strong> 0.3.10</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">


### PR DESCRIPTION
## Description

Removes `imagePullSecrets` from the job service account and instead injects them directly into activity pod specs via the worker. This is cleaner and avoids confusion — the job SA was the only reason imagePullSecrets were on it, and that coupling was non-obvious.

The worker now reads two new env vars from the configmap:
- `OLAKE_JOB_IMAGE_PULL_SECRETS` — JSON array of pull secret refs, set directly on `pod.Spec.ImagePullSecrets`
- `OLAKE_JOB_POD_ANNOTATIONS` — JSON map merged with internal `olake.io/*` annotations (internal keys always win)

Fully backward compatible — new worker handles absent env vars gracefully (old chart clients unaffected).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Scenario 1 — Fresh install (chart 0.0.24, worker 0.3.11, Harbor): activity pod gets `harbor-secret` + custom annotation
- [x] Scenario 2 — Empty `imagePullSecrets: []`: no panic, activity pod has no pull secrets 
- [x] Scenario 3 — Upgrade 0.0.22 → 0.0.24: configmap updated, new worker picks up new env vars 
- [x] Scenario 4 — New chart + old worker (v0.3.10): old worker ignores unknown env vars, no crash; upgrading worker alone enables features 
- [x] Scenario 5 — Old chart (0.0.22) + new worker: worker starts cleanly with absent env vars, no regression for existing clients