### PR TITLE
chore: staging -> master (olake-helm v0.0.25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ We ❤️ contributions! Check our [Bounty Program](https://olake.io/docs/commun
 ## Support
 
 - [GitHub Issues](https://github.com/datazip-inc/olake-helm/issues)
-- [Slack Community](https://join.slack.com/t/getolake/shared_invite/zt-2utw44do6-g4XuKKeqBghBMy2~LcJ4ag)
+- [Slack Community](https://olake.io/slack/)
 - [Documentation](https://olake.io/docs)

--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.24
+version: 0.0.25
 appVersion: "0.3.10"
 home: https://github.com/datazip-inc/olake-helm
 sources:

--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.23
+version: 0.0.24
 appVersion: "0.3.10"
 home: https://github.com/datazip-inc/olake-helm
 sources:

--- a/helm/olake/README.md
+++ b/helm/olake/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
     <a href="https://github.com/datazip-inc/olake-ui/issues"><img alt="GitHub issues" src="https://img.shields.io/github/issues/datazip-inc/olake"/></a> <a href="https://olake.io/docs"><img alt="Documentation" height="22" src="https://img.shields.io/badge/view-Documentation-blue?style=for-the-badge"/></a>
-    <a href="https://join.slack.com/t/getolake/shared_invite/zt-2utw44do6-g4XuKKeqBghBMy2~LcJ4ag"><img alt="slack" src="https://img.shields.io/badge/Join%20Our%20Community-Slack-blue"/></a>
+    <a href="https://olake.io/slack/"><img alt="slack" src="https://img.shields.io/badge/Join%20Our%20Community-Slack-blue"/></a>
 </p>
 
 ## Components
@@ -590,5 +590,5 @@ We ❤️ contributions! Check our [Bounty Program](https://olake.io/docs/commun
 ## Support
 
 - [GitHub Issues](https://github.com/datazip-inc/olake-ui/issues)
-- [Slack Community](https://join.slack.com/t/getolake/shared_invite/zt-2utw44do6-g4XuKKeqBghBMy2~LcJ4ag)
+- [Slack Community](https://olake.io/slack/)
 - [Documentation](https://olake.io/docs)

--- a/helm/olake/UNINSTALL_GUIDE.md
+++ b/helm/olake/UNINSTALL_GUIDE.md
@@ -286,6 +286,6 @@ If you kept PVCs during uninstall, the new installation will try to use them.
 
 For issues or questions:
 - [GitHub Issues](https://github.com/datazip-inc/olake-ui/issues)
-- [Slack Community](https://join.slack.com/t/getolake/shared_invite/zt-2utw44do6-g4XuKKeqBghBMy2~LcJ4ag)
+- [Slack Community](https://olake.io/slack/)
 - [Documentation](https://olake.io/docs)
 

--- a/helm/olake/templates/fusion/deployment.yaml
+++ b/helm/olake/templates/fusion/deployment.yaml
@@ -357,6 +357,25 @@ spec:
                 secretKeyRef:
                   name: {{ include "olake.postgresql.secretName" . }}
                   key: {{ if .Values.postgresql.enabled }}password{{ else }}{{ .Values.postgresql.external.secretKeys.password }}{{ end }}
+            {{- if and (not .Values.postgresql.enabled) .Values.postgresql.external.existingSecret }}
+            - name: _AMS_PG_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "olake.postgresql.secretName" . }}
+                  key: {{ .Values.postgresql.external.secretKeys.host }}
+            - name: _AMS_PG_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "olake.postgresql.secretName" . }}
+                  key: {{ .Values.postgresql.external.secretKeys.port }}
+            - name: _AMS_PG_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "olake.postgresql.secretName" . }}
+                  key: {{ .Values.postgresql.external.secretKeys.fusion_database }}
+            - name: AMS_DATABASE_URL
+              value: "jdbc:postgresql://$(_AMS_PG_HOST):$(_AMS_PG_PORT)/$(_AMS_PG_DB)"
+            {{- end }}
           {{- $defaultResources := dict
             "requests" (dict "memory" "512Mi" "cpu" "500m")
           }}

--- a/helm/olake/templates/olake-ui/deployment.yaml
+++ b/helm/olake/templates/olake-ui/deployment.yaml
@@ -198,7 +198,7 @@ spec:
           "timeoutSeconds" 5
           "failureThreshold" 3
           "successThreshold" 1
-          "exec" (dict "command" (list "/bin/sh" "-c" (printf "timeout 3 sh -c 'echo ok > /tmp/olake-config/.healthcheck-ui' && nc -z localhost %s" (.Values.olakeUI.env.HTTP_PORT | default "8000"))))
+          "exec" (dict "command" (list "/bin/sh" "-c" (printf "echo ok > /tmp/olake-config/.healthcheck-ui && nc -z localhost %s" (.Values.olakeUI.env.HTTP_PORT | default "8000"))))
         }}
         {{- $readinessProbe := mergeOverwrite $defaultReadinessProbe (.Values.olakeUI.readinessProbe | default dict) }}
         readinessProbe:
@@ -209,7 +209,7 @@ spec:
           "timeoutSeconds" 10
           "failureThreshold" 3
           "successThreshold" 1
-          "exec" (dict "command" (list "/bin/sh" "-c" (printf "timeout 3 sh -c 'echo ok > /tmp/olake-config/.healthcheck-ui' && nc -z localhost %s" (.Values.olakeUI.env.HTTP_PORT | default "8000"))))
+          "exec" (dict "command" (list "/bin/sh" "-c" (printf "echo ok > /tmp/olake-config/.healthcheck-ui && nc -z localhost %s" (.Values.olakeUI.env.HTTP_PORT | default "8000"))))
         }}
         {{- $livenessProbe := mergeOverwrite $defaultLivenessProbe (.Values.olakeUI.livenessProbe | default dict) }}
         livenessProbe:

--- a/helm/olake/templates/olake-worker/deployment.yaml
+++ b/helm/olake/templates/olake-worker/deployment.yaml
@@ -150,7 +150,7 @@ spec:
           "timeoutSeconds" 5
           "failureThreshold" 3
           "successThreshold" 1
-          "exec" (dict "command" (list "/bin/sh" "-c" "timeout 3 sh -c 'echo ok > /data/olake-jobs/.healthcheck' && wget -q --spider --timeout=2 http://localhost:8090/ready"))
+          "exec" (dict "command" (list "/bin/sh" "-c" "echo ok > /data/olake-jobs/.healthcheck && wget -q --spider --timeout=2 http://localhost:8090/ready"))
         }}
         {{- $readinessProbe := mergeOverwrite $defaultReadinessProbe (.Values.olakeWorker.readinessProbe | default dict) }}
         readinessProbe:
@@ -161,7 +161,7 @@ spec:
           "timeoutSeconds" 10
           "failureThreshold" 3
           "successThreshold" 1
-          "exec" (dict "command" (list "/bin/sh" "-c" "timeout 3 sh -c 'echo ok > /data/olake-jobs/.healthcheck' && wget -q --spider --timeout=2 http://localhost:8090/health"))
+          "exec" (dict "command" (list "/bin/sh" "-c" "echo ok > /data/olake-jobs/.healthcheck && wget -q --spider --timeout=2 http://localhost:8090/health"))
         }}
         {{- $livenessProbe := mergeOverwrite $defaultLivenessProbe (.Values.olakeWorker.livenessProbe | default dict) }}
         livenessProbe:

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -78,7 +78,7 @@ global:
   # -- Service account configuration for job pods created by olake-workers
   # Used for cloud provider IAM integration (AWS IRSA, GCP Workload Identity, Azure Workload Identity)
   jobServiceAccount:
-    create: false
+    create: true
     name: ""
 
     # Used for cloud provider IAM role association

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@ helm install olake olake/olake
         <p>
             <a href="https://github.com/datazip-inc/olake-helm" target="_blank">GitHub</a> |
             <a href="https://olake.io/docs" target="_blank">Documentation</a> |
-            <a href="https://join.slack.com/t/getolake/shared_invite/zt-2utw44do6-g4XuKKeqBghBMy2~LcJ4ag" target="_blank">Slack Community</a> |
+            <a href="https://olake.io/slack/" target="_blank">Slack Community</a> |
             <a href="https://github.com/datazip-inc/olake-helm/issues" target="_blank">Issues</a>
         </p>
         <p>&copy; 2024 DataZip Inc. Licensed under <a href="https://github.com/datazip-inc/olake-helm/blob/master/LICENSE" target="_blank">Apache 2.0</a></p>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.24</p>
+                <p><strong>Version:</strong> 0.0.25</p>
                 <p><strong>App Version:</strong> 0.3.10</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.23</p>
+                <p><strong>Version:</strong> 0.0.24</p>
                 <p><strong>App Version:</strong> 0.3.10</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">


### PR DESCRIPTION
# Description

- Nodes were hitting PID exhaustion after ~2 days, causing pods to enter StartError while the node remained in Ready state.
- Fixes a bug where enabling Fusion on an existing OLake deployment that uses postgresql.external.existingSecret causes the Fusion (Amoro AMS) pod to crash with Connection to localhost:5432 refused.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested end-to-end in a GKE cluster (`olake-test` namespace) against an external PostgreSQL instance using `existingSecret`:

- [x] **Reproduce bug:** Installed v0.0.23 (fusion disabled) → upgraded to v0.0.24 (fusion enabled) → confirmed crash with `Connection to localhost:5432 refused. Check that the hostname and port are correct`
- [x] **Verify fix:** Upgraded to patched chart (fusion enabled) → confirmed `AMS_DATABASE_URL=jdbc:postgresql://<external-host>:5432/fusion` logged by Amoro → no connection error → `Fusion is ready!` → Spark optimizer pod launched successfully
- [x] **Env var injection:** `kubectl exec` confirmed `_AMS_PG_HOST`, `_AMS_PG_PORT`, `_AMS_PG_DB`, and `AMS_DATABASE_URL` all correctly sourced from the secret
- [x] **No regression:** All other pods (workers, temporal, UI, nfs-server) remained healthy throughout the upgrade cycle

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
