### PR TITLE
chore: upgrade go version go1.25.12 and remove govulnignore entries

### DIFF
--- a/.govulnignore
+++ b/.govulnignore
@@ -1,8 +1,1 @@
-# TODO: Remove all entries below once Go 1.25.11 is available in https://storage.googleapis.com/golang/go1.25.11.linux-amd64.tar.gz
-#
-# GO-2026-5037: Inefficient candidate hostname parsing in crypto/x509
-GO-2026-5037
-# GO-2026-5038: Quadratic complexity in WordDecoder.DecodeHeader in mime
-GO-2026-5038
-# GO-2026-5039: Arbitrary inputs are included in errors without any escaping in net/textproto
-GO-2026-5039
+# Add GO-XXXX-XXXX identifiers here to suppress govulncheck findings.

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25.10-alpine AS builder
+FROM golang:1.25.12-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake-helm/worker
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/apache/spark-connect-go/v35 v35.0.0-20250317154112-ffd832059443

--- a/worker/main.go
+++ b/worker/main.go
@@ -106,5 +106,3 @@ func main() {
 	worker.Stop()
 	logger.Info("worker stopped!")
 }
-
-// trigger IT test

--- a/worker/main.go
+++ b/worker/main.go
@@ -106,3 +106,5 @@ func main() {
 	worker.Stop()
 	logger.Info("worker stopped!")
 }
+
+// trigger IT test


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

1. Upgrade worker Go version from `1.25.10` -> `1.25.12`
2. Remove redundant `.govulnignore` entries

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Scenario A
Ran IT tests

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):
