### PR TITLE
chore: staging -> master (olake-helm v0.0.27)

### DIFF
--- a/.govulnignore
+++ b/.govulnignore
@@ -1,8 +1,1 @@
-# TODO: Remove all entries below once Go 1.25.11 is available in https://storage.googleapis.com/golang/go1.25.11.linux-amd64.tar.gz
-#
-# GO-2026-5037: Inefficient candidate hostname parsing in crypto/x509
-GO-2026-5037
-# GO-2026-5038: Quadratic complexity in WordDecoder.DecodeHeader in mime
-GO-2026-5038
-# GO-2026-5039: Arbitrary inputs are included in errors without any escaping in net/textproto
-GO-2026-5039
+# Add GO-XXXX-XXXX identifiers here to suppress govulncheck findings.

--- a/helm/olake/Chart.yaml
+++ b/helm/olake/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: olake
 description: A Helm chart for OLake UI - Fastest open-source tool for replicating Databases to Apache Iceberg or Data Lakehouse
 type: application
-version: 0.0.26
+version: 0.0.27
 appVersion: "0.3.10"
 home: https://github.com/datazip-inc/olake-helm
 sources:

--- a/helm/olake/README.md
+++ b/helm/olake/README.md
@@ -167,6 +167,45 @@ global:
 
 **Deprecation Notice:** The legacy `global.jobMapping` configuration (which only supported `nodeSelector`) is deprecated and will be removed in a future release. Users are strongly advised to migrate to `global.jobProfiles`, which provides feature-rich scheduling capabilities including tolerations and affinity rules.
 
+### Fusion Compaction Scheduling
+
+Fusion runs two kinds of pods with very different resource profiles:
+
+- The **Fusion pod** and the **optimizer** pod — a lightweight, always-on orchestrator.
+- The **executor** pod(s) — created on-demand when compaction runs, and typically need much more memory/CPU (larger tables = bigger executors).
+
+Running both on the same node pool means keeping a large node around even when compaction isn't active. To avoid that, the Fusion pod and optimizer can be scheduled independently from the executor pods:
+
+```yaml
+fusion:
+  nodeSelector:
+    node-type: "olake-standard"
+  tolerations:
+    - key: "service"
+      operator: "Equal"
+      value: "olake"
+      effect: "NoSchedule"
+  affinity: {}
+
+  optimizer:
+    # If left empty, falls back to fusion.nodeSelector / tolerations / affinity above.
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
+    spark:
+      executor:
+        # If left empty, falls back to fusion.nodeSelector / tolerations / affinity above.
+        nodeSelector:
+          node-type: "olake-compaction-large"
+        tolerations:
+          - key: "compaction"
+            operator: "Equal"
+            value: "true"
+            effect: "NoSchedule"
+        affinity: {}
+```
+
 ### Cloud IAM Integration
 
 OLake's "activity pods" (the pods by which the actual data sync is performed) can be allowed to securely access cloud resources(AWS Glue or S3) using IAM roles.

--- a/helm/olake/templates/fusion/configmap.yaml
+++ b/helm/olake/templates/fusion/configmap.yaml
@@ -65,8 +65,8 @@ data:
           spark-conf.spark.kubernetes.authenticate.executor.serviceAccountName: "{{ include "olake.fusionServiceAccountName" . }}"
           spark-conf.spark.kubernetes.driver.label.olake.io/workload: "fusion-master"
           spark-conf.spark.kubernetes.executor.label.olake.io/workload: "fusion-executor"
-          spark-conf.spark.kubernetes.driver.podTemplateFile: "/usr/local/amoro/conf/pod-template.yaml"
-          spark-conf.spark.kubernetes.executor.podTemplateFile: "/usr/local/amoro/conf/pod-template.yaml"
+          spark-conf.spark.kubernetes.driver.podTemplateFile: "/usr/local/amoro/conf/driver-pod-template.yaml"
+          spark-conf.spark.kubernetes.executor.podTemplateFile: "/usr/local/amoro/conf/executor-pod-template.yaml"
           # Configs to prevent spark context from getting failed on executor failures
           # Number of retries by spark = spark-conf.spark.task.maxFailures - 1
           spark-conf.spark.executor.maxNumFailures: "2147483647"
@@ -93,7 +93,7 @@ data:
           {{ $key }}: "{{ $value }}"
           {{- end }}
 
-  pod-template.yaml: |
+  driver-pod-template.yaml: |
     apiVersion: v1
     kind: Pod
     metadata:
@@ -102,23 +102,51 @@ data:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
-      {{- if empty .Values.fusion.nodeSelector }}
+      {{- if empty (.Values.fusion.optimizer.nodeSelector | default .Values.fusion.nodeSelector) }}
       nodeSelector: {}
       {{- else }}
       nodeSelector:
-        {{- toYaml .Values.fusion.nodeSelector | nindent 8 }}
+        {{- toYaml (.Values.fusion.optimizer.nodeSelector | default .Values.fusion.nodeSelector) | nindent 8 }}
       {{- end }}
-      {{- if empty .Values.fusion.tolerations }}
+      {{- if empty (.Values.fusion.optimizer.tolerations | default .Values.fusion.tolerations) }}
       tolerations: []
       {{- else }}
       tolerations:
-        {{- toYaml .Values.fusion.tolerations | nindent 8 }}
+        {{- toYaml (.Values.fusion.optimizer.tolerations | default .Values.fusion.tolerations) | nindent 8 }}
       {{- end }}
-      {{- if empty .Values.fusion.affinity }}
+      {{- if empty (.Values.fusion.optimizer.affinity | default .Values.fusion.affinity) }}
       affinity: {}
       {{- else }}
       affinity:
-        {{- toYaml .Values.fusion.affinity | nindent 8 }}
+        {{- toYaml (.Values.fusion.optimizer.affinity | default .Values.fusion.affinity) | nindent 8 }}
+      {{- end }}
+
+  executor-pod-template.yaml: |
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      {{- with .Values.global.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if empty (.Values.fusion.optimizer.spark.executor.nodeSelector | default .Values.fusion.nodeSelector) }}
+      nodeSelector: {}
+      {{- else }}
+      nodeSelector:
+        {{- toYaml (.Values.fusion.optimizer.spark.executor.nodeSelector | default .Values.fusion.nodeSelector) | nindent 8 }}
+      {{- end }}
+      {{- if empty (.Values.fusion.optimizer.spark.executor.tolerations | default .Values.fusion.tolerations) }}
+      tolerations: []
+      {{- else }}
+      tolerations:
+        {{- toYaml (.Values.fusion.optimizer.spark.executor.tolerations | default .Values.fusion.tolerations) | nindent 8 }}
+      {{- end }}
+      {{- if empty (.Values.fusion.optimizer.spark.executor.affinity | default .Values.fusion.affinity) }}
+      affinity: {}
+      {{- else }}
+      affinity:
+        {{- toYaml (.Values.fusion.optimizer.spark.executor.affinity | default .Values.fusion.affinity) | nindent 8 }}
       {{- end }}
 
 {{- end }}

--- a/helm/olake/templates/fusion/deployment.yaml
+++ b/helm/olake/templates/fusion/deployment.yaml
@@ -317,8 +317,11 @@ spec:
               mountPath: /usr/local/amoro/conf/config.yaml
               subPath: config.yaml
             - name: fusion-config
-              mountPath: /usr/local/amoro/conf/pod-template.yaml
-              subPath: pod-template.yaml
+              mountPath: /usr/local/amoro/conf/driver-pod-template.yaml
+              subPath: driver-pod-template.yaml
+            - name: fusion-config
+              mountPath: /usr/local/amoro/conf/executor-pod-template.yaml
+              subPath: executor-pod-template.yaml
             - name: spark-binaries
               mountPath: /opt/spark
             - name: shared-storage

--- a/helm/olake/templates/olake-ui/init-user.yaml
+++ b/helm/olake/templates/olake-ui/init-user.yaml
@@ -1,6 +1,7 @@
 {{- /*
 TODO: Remove the conditional TTL logic in a future release (e.g. v1.0.0).
 */ -}}
+{{- if .Values.olakeUI.initUser.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -116,3 +117,4 @@ spec:
   {{- if not .Values.useStandardResources }}
   ttlSecondsAfterFinished: 3600
   {{- end }}
+{{- end }}

--- a/helm/olake/values.yaml
+++ b/helm/olake/values.yaml
@@ -214,6 +214,8 @@ olakeUI:
 
   # -- Initialization user configuration
   initUser:
+    enabled: true
+
     # -- Use an existing Kubernetes secret for the admin user credentials.
     # If you provide a secret name, the job will use it instead of the direct values below.
     # The secret must contain keys for username, password, and email.
@@ -693,6 +695,10 @@ fusion:
 
   # --- Optimizer configuration (Spark-on-Kubernetes)
   optimizer:
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+
     spark:
       # Desired Spark optimizer parallelism.
       desiredParallelism: 3
@@ -703,6 +709,11 @@ fusion:
         repository: olakego/fusion-spark
         tag: latest
         pullPolicy: Always
+
+      executor:
+        nodeSelector: {}
+        tolerations: []
+        affinity: {}
 
       # Extra Spark config entries (map of key->value).
       # Example:

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@ helm install olake olake/olake
             <div class="chart-card">
                 <h3>olake</h3>
                 <p><strong>Description:</strong> A comprehensive Helm chart for deploying OLake UI and Worker components along with required infrastructure (PostgreSQL, Temporal, Elasticsearch, optional NFS server).</p>
-                <p><strong>Version:</strong> 0.0.26</p>
+                <p><strong>Version:</strong> 0.0.27</p>
                 <p><strong>App Version:</strong> 0.3.10</p>
                 <p><strong>Keywords:</strong> data-pipeline, elt, kubernetes, iceberg, data-lakehouse, olake</p>
                 <div style="margin-top: 15px;">

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25.10-alpine AS builder
+FROM golang:1.25.12-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/worker/go.mod
+++ b/worker/go.mod
@@ -1,6 +1,6 @@
 module github.com/datazip-inc/olake-helm/worker
 
-go 1.25.10
+go 1.25.12
 
 require (
 	github.com/apache/spark-connect-go/v35 v35.0.0-20250317154112-ffd832059443


### PR DESCRIPTION
# Description

Fusion runs the always-on Fusion/optimizer pods and the on-demand compaction executor pods on the same node pool today, since they share one `nodeSelector`/`tolerations`/`affinity` config. Executor pods often need much more memory (larger tables) than the optimizer, so users were forced to keep a large node pool running at all times just to serve occasional compaction executors.

This change adds independent Kubernetes scheduling for the Fusion/optimizer pod and the compaction executor pods, so executors can be routed to a separate, larger (and independently autoscaled) node pool while the optimizer stays on a small, always-on pool.

Also includes:
- small addition: `olakeUI.initUser.enabled` to allow skipping the one-time admin user signup Job entirely.
- Bump up go version on worker

Fixes # (issue)

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] `helm lint` and `helm template` pass with default values and with new `fusion.optimizer.*` / `fusion.optimizer.spark.executor.*` overrides set.
- [x] Backward compatibility: rendered `driver-pod-template.yaml` / `executor-pod-template.yaml` are byte-identical to the previous single shared `pod-template.yaml` when only the existing `fusion.nodeSelector`/`tolerations`/`affinity` are set (no new fields).
- [x] Live install on a real GKE cluster (`dz-stag-gke-apsouth1`, namespace `olake-test`) with distinct node pools:
  - Fusion pod + optimizer pod pinned to a tainted, labeled pool (`optimizer-medium-pool`, then `benchmark-spark-master-pool` to also cover tolerations + arm64) — confirmed via `kubectl describe pod` (`Node-Selectors`, `Tolerations`, `Node`).
  - Executor pods pinned to a separate tainted pool (`optimizer-large-pool`) — confirmed the **real** Spark driver (`amoro-optimizer-...`) and executor pods (`amoro-spark-optimizer-...-exec-1/2/3`) spawned by an actual compaction run landed on their respective correct nodes with correct `nodeSelector`/`tolerations`, all reaching `1/1 Running`.
- [x] `olakeUI.initUser.enabled=false` verified to omit the `olake-signup-init` Job entirely from rendered manifests, with no other template referencing it.

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):