### PR TITLE
fix(opt): increase spark sub-task max failures

### DIFF
--- a/helm/olake/templates/fusion/configmap.yaml
+++ b/helm/olake/templates/fusion/configmap.yaml
@@ -71,7 +71,7 @@ data:
           # Number of retries by spark = spark-conf.spark.task.maxFailures - 1
           spark-conf.spark.executor.maxNumFailures: "2147483647"
           spark-conf.spark.executor.failuresValidityInterval: "10ms"
-          spark-conf.spark.task.maxFailures: "4"
+          spark-conf.spark.task.maxFailures: "2"
           # Configurations for shared storage for logs
           spark-conf.spark.kubernetes.driver.volumes.persistentVolumeClaim.fusion-logs.mount.path: "/data/fusion-logs"
           spark-conf.spark.kubernetes.driver.volumes.persistentVolumeClaim.fusion-logs.mount.readOnly: "false"


### PR DESCRIPTION
## Description

Initially, Spark used to retry each sub-task 3 more in case the executor fails (e.g., because of OOM). Reducing that default value to `2` now. 