### PR TITLE
chore: gitignore local Claude Code tooling state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ temp/
 
 # Ignore DevSpace cache and log folder
 .devspace/
+.cocoindex_code/
+CLAUDE.local.md


### PR DESCRIPTION
Adds `.cocoindex_code/` (local semantic-search index/settings) and `CLAUDE.local.md` (personal Claude Code agent instructions) to .gitignore.

These are machine-local dev tooling artifacts (Claude Code + cocoindex-code + Graphiti setup) — not meant to be shared/tracked. No source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)