### PR TITLE
feat(charts): add shared nfs-server and postgresql charts

### DIFF
--- a/helm/nfs-server/.helmignore
+++ b/helm/nfs-server/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# test files
+test-values.yaml
+tests/

--- a/helm/nfs-server/Chart.yaml
+++ b/helm/nfs-server/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: nfs-server
+description: In-cluster NFS server and the shared ReadWriteMany claim used by the OLake and Fusion charts
+type: application
+version: 0.0.1
+appVersion: "4.0.8"
+home: https://github.com/datazip-inc/olake-helm
+sources:
+  - https://github.com/datazip-inc/olake-helm
+keywords:
+  - nfs
+  - storage
+  - readwritemany
+  - kubernetes
+  - olake
+maintainers:
+  - name: Team OLake
+    email: hello@olake.io
+dependencies: []

--- a/helm/nfs-server/README.md
+++ b/helm/nfs-server/README.md
@@ -1,0 +1,43 @@
+# nfs-server
+
+Shared storage for the OLake charts: an in-cluster NFS server with dynamic
+provisioning, plus the ReadWriteMany claim that OLake workers and Fusion mount
+for logs and connector state.
+
+This chart is not meant to be installed on its own. It is a dependency of both
+[`olake`](../olake/README.md) and [`fusion`](../fusion/README.md), aliased to
+`nfsServer` in each, so it is configured through `nfsServer.*` in whichever
+chart you install:
+
+```yaml
+nfsServer:
+  enabled: true
+  persistence:
+    size: 20Gi
+```
+
+Set `nfsServer.enabled: false` to skip the NFS server and provision the shared
+claim from a ReadWriteMany StorageClass you already have (AWS EFS, Azure Files,
+GCP Filestore, Longhorn, Rook/CephFS). `nfsServer.external.storageClass` is
+required in that case. The claim is created either way — that is why this chart
+always renders.
+
+## Resource names
+
+Resource names are built from `nameOverride` (default `olake`) rather than this
+chart's own name, so they match what the `olake` chart created before this chart
+was split out of it. The StatefulSet, Service, ServiceAccount, ClusterRole,
+ClusterRoleBinding and StorageClass all carry `helm.sh/resource-policy: keep`;
+renaming them would orphan the live objects instead of upgrading them. The
+`fusion` chart overrides `nameOverride` to `fusion` and sets its own
+`claimName` and `storageClass.name` so a standalone Fusion install does not
+collide with an `olake` install on the same cluster.
+
+## Caveats
+
+The bundled NFS server runs as a single pod: convenient for development and
+quick starts, a single point of failure in production. It is also incompatible
+with Bottlerocket OS worker nodes on AWS EKS — use EFS there via
+`nfsServer.enabled: false`.
+
+See [values.yaml](values.yaml) — every key is documented inline.

--- a/helm/nfs-server/templates/_helpers.tpl
+++ b/helm/nfs-server/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/*
+Base name that resource names are built from.
+
+This deliberately mirrors the `olake.fullname` helper this chart was split out
+of, using `nameOverride` (default "olake") in place of `.Chart.Name`. Keeping
+the base identical means the StatefulSet, Service, ServiceAccount, ClusterRole,
+ClusterRoleBinding and StorageClass keep the names they already have in live
+clusters - all of them carry `helm.sh/resource-policy: keep`, so a rename would
+orphan the existing objects instead of upgrading them.
+*/}}
+{{- define "nfs-server.base" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := .Values.nameOverride | default "olake" -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Short name used in `app.kubernetes.io/name` labels
+*/}}
+{{- define "nfs-server.name" -}}
+{{- .Values.nameOverride | default "olake" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified name of the NFS server resources
+*/}}
+{{- define "nfs-server.fullname" -}}
+{{- printf "%s-nfs-server" (include "nfs-server.base" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Get the namespace name
+*/}}
+{{- define "nfs-server.namespace" -}}
+{{- .Values.namespaceOverride | default .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "nfs-server.labels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+olake.io/part-of: olake
+{{- end }}
+
+{{/*
+Name of the shared ReadWriteMany claim that Fusion and the OLake worker mount.
+Release independent on purpose: both parent charts resolve the same claim name
+from the same values, so either can create it and the other can mount it.
+*/}}
+{{- define "nfs-server.sharedStoragePVC" -}}
+{{- if .Values.claimName -}}
+{{- .Values.claimName -}}
+{{- else if .Values.enabled -}}
+olake-shared-storage
+{{- else -}}
+{{- .Values.external.name | default "olake-shared-storage" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Calculate shared storage size based on NFS server backing storage
+Reserves 2Gi for filesystem overhead
+*/}}
+{{- define "nfs-server.sharedStorageSize" -}}
+{{- $nfsSize := .Values.persistence.size | default "20Gi" -}}
+{{- $sizeValue := regexReplaceAll "([0-9]+).*" $nfsSize "${1}" | int -}}
+{{- $sizeUnit := regexReplaceAll "[0-9]+(.*)" $nfsSize "${1}" -}}
+{{- $adjustedSize := sub $sizeValue 2 -}}
+{{- printf "%d%s" $adjustedSize $sizeUnit -}}
+{{- end -}}
+
+{{/*
+Return the container registry base URL.
+Uses CONTAINER_REGISTRY_BASE from global.env if set, otherwise defaults to registry-1.docker.io
+*/}}
+{{- define "nfs-server.registryBase" -}}
+{{- .Values.global.env.CONTAINER_REGISTRY_BASE | default "registry-1.docker.io" -}}
+{{- end -}}

--- a/helm/nfs-server/templates/nfs-server-rbac.yaml
+++ b/helm/nfs-server/templates/nfs-server-rbac.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nfs-server.base" . }}-nfs-server
+  namespace: {{ include "nfs-server.namespace" . }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app.kubernetes.io/name: {{ include "nfs-server.name" . }}-nfs-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: nfs-server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "nfs-server.base" . }}-nfs-server
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    # Static labels only - no dynamic chart version labels
+    app.kubernetes.io/name: {{ include "nfs-server.name" . }}-nfs-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: nfs-server
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch", "create", "delete"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "update", "patch"]
+- apiGroups: [""]
+  resources: ["services", "endpoints"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: ["nfs-provisioner"]
+  verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "nfs-server.base" . }}-nfs-server
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    # Static labels only - no dynamic chart version labels
+    app.kubernetes.io/name: {{ include "nfs-server.name" . }}-nfs-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: nfs-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "nfs-server.base" . }}-nfs-server
+subjects:
+- kind: ServiceAccount
+  name: {{ include "nfs-server.base" . }}-nfs-server
+  namespace: {{ include "nfs-server.namespace" . }}
+{{- end }}

--- a/helm/nfs-server/templates/nfs-server-service.yaml
+++ b/helm/nfs-server/templates/nfs-server-service.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nfs-server.base" . }}-nfs-server
+  namespace: {{ include "nfs-server.namespace" . }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app.kubernetes.io/name: {{ include "nfs-server.name" . }}-nfs-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: nfs-server
+spec:
+  type: ClusterIP
+  ports:
+  - name: nfs
+    port: 2049
+    protocol: TCP
+  - name: nfs-udp
+    port: 2049
+    protocol: UDP
+  - name: mountd
+    port: 20048
+    protocol: TCP
+  - name: mountd-udp
+    port: 20048
+    protocol: UDP
+  - name: rpcbind
+    port: 111
+    protocol: TCP
+  - name: rpcbind-udp
+    port: 111
+    protocol: UDP
+  - name: nlockmgr-tcp
+    port: 32803
+    protocol: TCP
+  - name: nlockmgr-udp
+    port: 32803
+    protocol: UDP
+  - name: status-tcp
+    port: 662
+    protocol: TCP
+  - name: status-udp
+    port: 662
+    protocol: UDP
+  - name: rquotad-tcp
+    port: 875
+    protocol: TCP
+  - name: rquotad-udp
+    port: 875
+    protocol: UDP
+  selector:
+    app.kubernetes.io/name: {{ include "nfs-server.name" . }}-nfs-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: nfs-server
+{{- end }}

--- a/helm/nfs-server/templates/nfs-server-statefulset.yaml
+++ b/helm/nfs-server/templates/nfs-server-statefulset.yaml
@@ -1,0 +1,150 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "nfs-server.base" . }}-nfs-server
+  namespace: {{ include "nfs-server.namespace" . }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  labels:
+    app.kubernetes.io/name: {{ include "nfs-server.name" . }}-nfs-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: nfs-server
+spec:
+  serviceName: {{ include "nfs-server.base" . }}-nfs-server
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "nfs-server.name" . }}-nfs-server
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: nfs-server
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "nfs-server.name" . }}-nfs-server
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: nfs-server
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "nfs-server.base" . }}-nfs-server
+      containers:
+      - name: nfs-server
+        {{- if .Values.global.env.CONTAINER_REGISTRY_BASE }}
+        image: "{{ include "nfs-server.registryBase" . }}/sig-storage/nfs-provisioner:v4.0.8"
+        {{- else }}
+        image: "registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8"
+        {{- end }}
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: nfs
+          containerPort: 2049
+        - name: nfs-udp
+          containerPort: 2049
+          protocol: UDP
+        - name: mountd
+          containerPort: 20048
+        - name: mountd-udp
+          containerPort: 20048
+          protocol: UDP
+        - name: rpcbind
+          containerPort: 111
+        - name: rpcbind-udp
+          containerPort: 111
+          protocol: UDP
+        - name: nlockmgr-tcp
+          containerPort: 32803
+        - name: nlockmgr-udp
+          containerPort: 32803
+          protocol: UDP
+        - name: status-tcp
+          containerPort: 662
+        - name: status-udp
+          containerPort: 662
+          protocol: UDP
+        - name: rquotad-tcp
+          containerPort: 875
+        - name: rquotad-udp
+          containerPort: 875
+          protocol: UDP
+        securityContext:
+          capabilities:
+            add:
+              - DAC_READ_SEARCH
+              - SYS_RESOURCE
+        args:
+          - "-provisioner={{ include "nfs-server.base" . }}/nfs-server"
+          - "-grace-period=0"
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_NAME
+          value: {{ include "nfs-server.base" . }}-nfs-server
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: export-volume
+          mountPath: /export
+        readinessProbe:
+          tcpSocket:
+            port: 2049
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
+        livenessProbe:
+          tcpSocket:
+            port: 2049
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        {{- $defaultResources := dict 
+          "requests" (dict "cpu" "250m" "memory" "256Mi")
+          "limits" (dict "cpu" "500m" "memory" "512Mi")
+        }}
+        {{- $resources := mergeOverwrite $defaultResources (.Values.resources | default dict) }}
+        resources:
+          {{- toYaml $resources | nindent 10 }}
+  volumeClaimTemplates:
+  - metadata:
+      name: export-volume
+      annotations:
+        "helm.sh/resource-policy": keep
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | default "20Gi" }}
+      {{- if .Values.global.storageClass }}
+      storageClassName: {{ .Values.global.storageClass }}
+      {{- end }}
+{{- end }}

--- a/helm/nfs-server/templates/nfs-server-storageclass.yaml
+++ b/helm/nfs-server/templates/nfs-server-storageclass.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.enabled }}
+{{- /* Define a static name for the StorageClass */}}
+{{- $scName := .Values.storageClass.name | default "nfs-server" -}}
+
+{{- /* Use 'lookup' to see if the StorageClass already exists. */}}
+{{- /* The empty "" for namespace is correct for a cluster-scoped resource. */}}
+{{- $existingSc := lookup "storage.k8s.io/v1" "StorageClass" "" $scName -}}
+
+{{- /* Only render the template if the StorageClass does not exist */}}
+{{- if not $existingSc }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $scName }}
+  annotations:
+    # This policy is still important to prevent deletion on `helm uninstall`.
+    "helm.sh/resource-policy": keep
+  labels:
+    app.kubernetes.io/name: {{ include "nfs-server.name" . }}-nfs-server
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: storage-class
+provisioner: {{ include "nfs-server.base" . }}/nfs-server
+parameters: {}
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+mountOptions:
+  - vers=4.1
+  - rsize=1048576
+  - wsize=1048576
+  - hard
+  - timeo=600
+  - retrans=2
+{{- end }}
+{{- end }}

--- a/helm/nfs-server/templates/shared-storage-pvc.yaml
+++ b/helm/nfs-server/templates/shared-storage-pvc.yaml
@@ -1,0 +1,26 @@
+{{- if not .Values.enabled }}
+{{- if not .Values.external.storageClass }}
+{{- fail "nfsServer.external.storageClass is required when nfsServer.enabled is false" }}
+{{- end }}
+{{- end }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "nfs-server.sharedStoragePVC" . }}
+  namespace: {{ include "nfs-server.namespace" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "nfs-server.name" . }}-shared-storage
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: shared-storage
+    {{- include "nfs-server.labels" . | nindent 4 }}
+  {{- if or .Values.enabled (not .Values.external.deletePVCOnUninstall) }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{- if .Values.enabled }} {{ include "nfs-server.sharedStorageSize" . }}{{- else }} {{ .Values.external.size }}{{- end }}
+  storageClassName: {{- if .Values.enabled }} {{ .Values.storageClass.name | default "nfs-server" }}{{- else }} {{ .Values.external.storageClass }}{{- end }}

--- a/helm/nfs-server/values.yaml
+++ b/helm/nfs-server/values.yaml
@@ -1,0 +1,110 @@
+# Default values for the nfs-server chart.
+#
+# This chart is a shared dependency of both the `olake` and `fusion` charts. It
+# deploys an in-cluster NFS server with dynamic provisioning and always creates
+# the shared ReadWriteMany claim that Fusion and the OLake worker mount.
+#
+# Both parents alias this chart to `nfsServer`, so these keys are configured as
+# `nfsServer.*` from either parent's values file, exactly as before the split.
+
+# -- Base name used when building resource names.
+# Kept at "olake" so resource names are byte-identical to the ones the olake
+# chart created before this chart was split out. The NFS StatefulSet, Service,
+# ServiceAccount, ClusterRole and ClusterRoleBinding all carry
+# `helm.sh/resource-policy: keep`, so renaming them would orphan the live
+# objects on upgrade. The fusion chart overrides this to "fusion".
+nameOverride: "olake"
+
+# -- Fully override the resource name base, ignoring nameOverride and the release name
+fullnameOverride: ""
+
+# -- Override the namespace that resources are deployed into
+namespaceOverride: ""
+
+# -- Global configuration, propagated by Helm from whichever chart installs this one
+global:
+  # -- Global image pull secrets for private container registries
+  imagePullSecrets: []
+  # -- StorageClass for the NFS server's own backing volume
+  storageClass: ""
+  # -- Global environment values. CONTAINER_REGISTRY_BASE redirects image pulls
+  # to a private registry mirror.
+  env: {}
+
+# -- Enable NFS server deployment with dynamic provisioning
+# IMPORTANT: NFS components are created once and persist across helm operations.
+# They will NOT be deleted on 'helm uninstall' or modified on 'helm upgrade'.
+# This ensures data persistence but requires manual management for updates.
+enabled: true
+
+# -- External storage configuration (used when enabled: false)
+# When disabled, you must provide an existing ReadWriteMany (RWX) supported StorageClass
+#
+# CLOUD PROVIDER GUIDES FOR RWX STORAGECLASS:
+#
+# AWS EFS: Use the Amazon EFS CSI driver with 'efs.csi.aws.com' provisioner
+# See: https://github.com/kubernetes-sigs/aws-efs-csi-driver
+#
+# Azure Files: Use 'azurefile' StorageClass with 'kubernetes.io/azure-file' provisioner
+# See: https://docs.microsoft.com/en-us/azure/aks/azure-files-csi
+#
+# GCP Filestore: Use Google Cloud Filestore CSI driver with 'filestore.csi.storage.gke.io' provisioner
+# See: https://cloud.google.com/filestore/docs/csi-driver
+external:
+  # -- Name for the external PVC
+  # If not provided, defaults to "olake-shared-storage"
+  # Use this to reference an existing PVC or customize the name
+  name: ""
+
+  # -- StorageClass for dynamic RWX PVC creation
+  # Required when nfsServer.enabled is false
+  # Examples: "efs-sc", "azurefile", "filestore-csi", "longhorn", "rook-cephfs"
+  storageClass: ""
+
+  # -- Size for the dynamically created external PVC
+  size: "20Gi"
+
+  # -- Delete the external PVC on helm uninstall
+  deletePVCOnUninstall: false
+
+# -- Pod scheduling constraints
+nodeSelector: {}
+
+# -- Tolerations for pod assignment
+tolerations: []
+
+# -- Affinity settings for pod assignment
+affinity: {}
+
+# -- Additional pod annotations
+podAnnotations: {}
+
+# -- Additional pod labels
+podLabels: {}
+
+# -- Persistence configuration for NFS server backing storage
+persistence:
+  # -- Size of backing storage for NFS server
+  size: 20Gi
+
+# -- StorageClass configuration for dynamic provisioning
+storageClass:
+  # -- Name of the StorageClass created by NFS server
+  name: "nfs-server"
+
+# -- NFS Server resource requirements (optional overrides)
+# Defaults: requests: memory=256Mi, cpu=250m ; limits: memory=512Mi, cpu=500m
+# Example customizations:
+# resources:
+#   requests:
+#     memory: "1Gi"
+#     cpu: "750m"
+#   limits:
+#     memory: "2Gi"
+#     cpu: "1500m"
+resources: {}
+
+
+# -- Name of the shared claim. Empty keeps the historical "olake-shared-storage"
+# name; a standalone Fusion install sets this to its own claim.
+claimName: ""

--- a/helm/postgresql/.helmignore
+++ b/helm/postgresql/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# test files
+test-values.yaml
+tests/

--- a/helm/postgresql/Chart.yaml
+++ b/helm/postgresql/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: postgresql
+description: PostgreSQL instance backing the OLake and Fusion charts
+type: application
+version: 0.0.1
+appVersion: "14"
+home: https://github.com/datazip-inc/olake-helm
+sources:
+  - https://github.com/datazip-inc/olake-helm
+keywords:
+  - postgresql
+  - database
+  - kubernetes
+  - olake
+maintainers:
+  - name: Team OLake
+    email: hello@olake.io
+dependencies: []

--- a/helm/postgresql/README.md
+++ b/helm/postgresql/README.md
@@ -1,0 +1,57 @@
+# postgresql
+
+PostgreSQL instance backing the OLake charts. A single server holds a database
+per consumer — OLake UI, Temporal, and Fusion — recorded as separate keys in one
+credentials secret.
+
+This chart is not meant to be installed on its own. It is a dependency of both
+[`olake`](../olake/README.md) and [`fusion`](../fusion/README.md), aliased to
+`postgresql` in each, so it is configured through `postgresql.*` in whichever
+chart you install:
+
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    postgresUser: temporal
+    postgresPassword: change-me
+  persistence:
+    size: 8Gi
+```
+
+Set `postgresql.enabled: false` to skip it entirely and point the parent at a
+database you already run. Each parent keeps its own `postgresql.external` block
+for that; those keys are read by the parent's templates and ignored here.
+
+## Names you should not change
+
+Two values are load bearing on an existing install:
+
+- **`serviceName`** (default `postgresql`) names both the StatefulSet and its
+  headless Service. The StatefulSet's volume claim is
+  `postgresql-storage-<serviceName>-0`, so changing it on a live release strands
+  the database volume and comes up with an empty database.
+- **`componentLabel`** (default `database`) is part of the StatefulSet's
+  selector. Kubernetes treats `spec.selector` as immutable, so changing it makes
+  `helm upgrade` fail outright.
+
+The defaults reproduce exactly what the `olake` chart created before this chart
+was split out of it, so existing releases upgrade in place. The `fusion` chart
+overrides both, letting a standalone Fusion install run its own PostgreSQL
+alongside an `olake` install in the same namespace.
+
+## Databases
+
+`databases` maps a secret key to a database name:
+
+```yaml
+databases:
+  database: temporal
+  fusion_database: fusion
+```
+
+`primaryDatabaseKey` picks which of them becomes `POSTGRES_DB`, i.e. the
+database the server creates when it first initialises. The others are created by
+their own consumers.
+
+See [values.yaml](values.yaml) — every key is documented inline.

--- a/helm/postgresql/templates/_helpers.tpl
+++ b/helm/postgresql/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/*
+Base name that the secret name is built from.
+
+Mirrors the `olake.fullname` helper this chart was split out of, using
+`nameOverride` (default "olake") in place of `.Chart.Name`, so the secret keeps
+the name it already has in live clusters.
+*/}}
+{{- define "postgresql.base" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := .Values.nameOverride | default "olake" -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the StatefulSet and the headless Service.
+
+Defaults to the bare "postgresql" the olake chart has always used. That name is
+load bearing: the StatefulSet's volume claim is `postgresql-storage-<name>-0`,
+so changing it strands the database volume. A second instance in the same
+namespace (a standalone Fusion install) must override `serviceName`.
+*/}}
+{{- define "postgresql.fullname" -}}
+{{- .Values.serviceName | default "postgresql" -}}
+{{- end -}}
+
+{{/*
+Name of the credentials secret
+*/}}
+{{- define "postgresql.secretName" -}}
+{{- .Values.existingSecret | default (printf "%s-postgresql-secret" (include "postgresql.base" .)) -}}
+{{- end -}}
+
+{{- define "postgresql.namespace" -}}
+{{- .Values.namespaceOverride | default .Release.Namespace -}}
+{{- end -}}
+
+{{/*
+In-cluster DNS name the secret publishes as `host`
+*/}}
+{{- define "postgresql.host" -}}
+{{- printf "%s.%s.svc.%s" (include "postgresql.fullname" .) (include "postgresql.namespace" .) (.Values.clusterDomain | default "cluster.local") -}}
+{{- end -}}
+
+{{/*
+Selector labels. Immutable on an existing StatefulSet - do not change these.
+*/}}
+{{- define "postgresql.selectorLabels" -}}
+app.kubernetes.io/name: postgresql
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ .Values.componentLabel | default "database" }}
+{{- end -}}
+
+{{- define "postgresql.labels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+olake.io/part-of: olake
+{{- end -}}
+
+{{- define "postgresql.image" -}}
+{{- printf "%s/%s:%s" (.Values.global.env.CONTAINER_REGISTRY_BASE | default "registry-1.docker.io") .Values.image.repository .Values.image.tag -}}
+{{- end -}}

--- a/helm/postgresql/templates/secret.yaml
+++ b/helm/postgresql/templates/secret.yaml
@@ -1,0 +1,29 @@
+{{- /*
+TODO: Remove the Helm hook logic in a future release (e.g. v1.0.0).
+*/ -}}
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postgresql.secretName" . }}
+  namespace: {{ include "postgresql.namespace" . }}
+  annotations:
+    {{- if not .Values.useStandardResources }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- end }}
+  labels:
+    {{- include "postgresql.selectorLabels" . | nindent 4 }}
+    {{- include "postgresql.labels" . | nindent 4 }}
+type: Opaque
+data:
+  host: {{ include "postgresql.host" . | b64enc }}
+  port: {{ "5432" | b64enc }}
+  {{- range $key, $db := .Values.databases }}
+  {{ $key }}: {{ $db | b64enc }}
+  {{- end }}
+  username: {{ .Values.auth.postgresUser | b64enc }}
+  password: {{ .Values.auth.postgresPassword | b64enc }}
+  ssl_mode: {{ .Values.auth.sslMode | default "disable" | b64enc }}
+{{- end }}

--- a/helm/postgresql/templates/service.yaml
+++ b/helm/postgresql/templates/service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgresql.fullname" . }}
+  namespace: {{ include "postgresql.namespace" . }}
+  {{- with (.Values.service).annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "postgresql.selectorLabels" . | nindent 4 }}
+    {{- include "postgresql.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 5432
+    targetPort: 5432
+    protocol: TCP
+    name: postgres
+  selector:
+    {{- include "postgresql.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/postgresql/templates/statefulset.yaml
+++ b/helm/postgresql/templates/statefulset.yaml
@@ -1,0 +1,123 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "postgresql.fullname" . }}
+  namespace: {{ include "postgresql.namespace" . }}
+  annotations: {}
+  labels:
+    {{- include "postgresql.selectorLabels" . | nindent 4 }}
+    {{- include "postgresql.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "postgresql.fullname" . }}
+  selector:
+    matchLabels:
+      {{- include "postgresql.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.global.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "postgresql.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: postgresql
+        image: {{ include "postgresql.image" . | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: postgres
+          containerPort: 5432
+          protocol: TCP
+        env:
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "postgresql.secretName" . }}
+              key: {{ .Values.primaryDatabaseKey | default "database" }}
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "postgresql.secretName" . }}
+              key: username
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "postgresql.secretName" . }}
+              key: password
+        {{- $defaultResources := dict 
+          "requests" (dict "memory" "512Mi" "cpu" "500m")
+        }}
+        {{- $resources := mergeOverwrite $defaultResources (.Values.resources | default dict) }}
+        {{- $defaultReadinessProbe := dict 
+          "initialDelaySeconds" 5
+          "periodSeconds" 10
+          "timeoutSeconds" 5
+          "failureThreshold" 6
+          "successThreshold" 1
+          "exec" (dict "command" (list "/bin/sh" "-c" "exec pg_isready -U ${POSTGRES_USER} -h 127.0.0.1 -p 5432"))
+        }}
+        {{- $readinessProbe := mergeOverwrite $defaultReadinessProbe (.Values.readinessProbe | default dict) }}
+        readinessProbe:
+          {{- toYaml $readinessProbe | nindent 10 }}
+        {{- $defaultLivenessProbe := dict 
+          "initialDelaySeconds" 30
+          "periodSeconds" 10
+          "timeoutSeconds" 5
+          "failureThreshold" 6
+          "successThreshold" 1
+          "exec" (dict "command" (list "/bin/sh" "-c" "exec pg_isready -U ${POSTGRES_USER} -h 127.0.0.1 -p 5432"))
+        }}
+        {{- $livenessProbe := mergeOverwrite $defaultLivenessProbe (.Values.livenessProbe | default dict) }}
+        livenessProbe:
+          {{- toYaml $livenessProbe | nindent 10 }}
+        resources:
+          {{- toYaml $resources | nindent 10 }}
+        volumeMounts:
+        - name: postgresql-storage
+          mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+  - metadata:
+      name: postgresql-storage
+      labels:
+        {{- include "postgresql.selectorLabels" . | nindent 8 }}
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      {{- if .Values.global.storageClass }}
+      storageClassName: {{ .Values.global.storageClass | quote }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/helm/postgresql/values.yaml
+++ b/helm/postgresql/values.yaml
@@ -1,0 +1,102 @@
+# Default values for the postgresql chart.
+#
+# Shared dependency of the `olake` and `fusion` charts. Both alias it to
+# `postgresql`, so these keys are configured as `postgresql.*` from either
+# parent's values file, exactly as before the split.
+#
+# Parents keep their own `postgresql.external` block for pointing at a database
+# this chart did not create; those keys are read by the parent's templates and
+# ignored here.
+
+# -- Deploy PostgreSQL. When false this chart renders nothing and the parent is
+# expected to use its `postgresql.external` configuration instead.
+enabled: true
+
+# -- Base name the credentials secret is built from.
+# Kept at "olake" so the secret keeps the name it already has in live clusters.
+# The fusion chart overrides this to "fusion".
+nameOverride: "olake"
+
+# -- Fully override the secret name base, ignoring nameOverride and the release name
+fullnameOverride: ""
+
+# -- Override the namespace that resources are deployed into
+namespaceOverride: ""
+
+# -- Cluster DNS domain, used to build the host published in the secret
+clusterDomain: cluster.local
+
+# -- Name of the StatefulSet and its headless Service.
+# Load bearing: the StatefulSet's volume claim is `postgresql-storage-<name>-0`,
+# so changing this on an existing install strands the database volume. A second
+# instance in the same namespace must override it (the fusion chart does).
+serviceName: "postgresql"
+
+# -- Value of the `app.kubernetes.io/component` label.
+# Part of the StatefulSet selector, which Kubernetes treats as immutable -
+# changing it makes `helm upgrade` fail on an existing install.
+componentLabel: "database"
+
+# -- Use an existing secret instead of the one this chart creates
+existingSecret: ""
+
+# -- Create the secret as a standard resource rather than a Helm hook.
+# Mirrors the parent chart's own `useStandardResources` flag; set both together.
+useStandardResources: true
+
+# -- Databases to record in the secret, as `<secret key>: <database name>`.
+# One PostgreSQL instance backs several components, so the secret carries a key
+# per consumer rather than a single database name.
+databases:
+  database: temporal
+  fusion_database: fusion
+
+# -- Key from `databases` used as POSTGRES_DB when the server first initialises
+primaryDatabaseKey: "database"
+
+# -- Authentication configuration
+auth:
+  # -- PostgreSQL super user name
+  postgresUser: "temporal"
+  # -- PostgreSQL super user password
+  postgresPassword: "temporal"
+  # -- sslmode recorded in the secret
+  sslMode: "disable"
+
+# -- PostgreSQL image configuration
+image:
+  repository: library/postgres
+  tag: "14-alpine"
+  pullPolicy: Always
+
+# -- Persistent volume for PostgreSQL data
+persistence:
+  # -- Size of persistent volume for PostgreSQL data
+  size: 8Gi
+
+# -- Extra annotations for the PostgreSQL Service
+service:
+  annotations: {}
+
+# -- Pod scheduling constraints
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}
+podLabels: {}
+securityContext: {}
+
+# -- PostgreSQL resource requirements (optional overrides)
+# Defaults: requests: memory=512Mi, cpu=500m
+resources: {}
+
+# -- Probe overrides, merged over the chart defaults
+readinessProbe: {}
+livenessProbe: {}
+
+# -- Global configuration, propagated by Helm from whichever chart installs this one
+global:
+  imagePullSecrets: []
+  storageClass: ""
+  podAnnotations: {}
+  env: {}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Generic nfs-server and postgresql charts, that is shared by OLake and Fusion charts

## Type of change

<!--
Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Scenario A
- [ ] Scenario B

# Screenshots or Recordings
<!-- Attach related screenshots or recordings here -->

## Related PR's (If Any):

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>