### PR TITLE
 fix(worker/docker): add heartbeat during image pull

### DIFF
--- a/worker/executor/docker/container.go
+++ b/worker/executor/docker/container.go
@@ -48,7 +48,6 @@ func (w *heartbeatWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-
 func (d *DockerExecutor) PullImage(ctx context.Context, imageName, version string, heartbeatFunc func(context.Context, ...interface{})) error {
 	log := logger.Log(ctx)
 	_, err := d.client.ImageInspect(ctx, imageName)

--- a/worker/executor/docker/container.go
+++ b/worker/executor/docker/container.go
@@ -33,21 +33,6 @@ type ContainerState struct {
 	ExitCode *int
 }
 
-type heartbeatWriter struct {
-	ctx           context.Context
-	imageName     string
-	heartbeatFunc func(context.Context, ...interface{})
-	lastHeartbeat time.Time
-}
-
-func (w *heartbeatWriter) Write(p []byte) (int, error) {
-	if w.heartbeatFunc != nil && time.Since(w.lastHeartbeat) > 5*time.Second {
-		w.heartbeatFunc(w.ctx, fmt.Sprintf("pulling image %s", w.imageName))
-		w.lastHeartbeat = time.Now()
-	}
-	return len(p), nil
-}
-
 func (d *DockerExecutor) PullImage(ctx context.Context, imageName, version string, heartbeatFunc func(context.Context, ...interface{})) error {
 	log := logger.Log(ctx)
 	_, err := d.client.ImageInspect(ctx, imageName)
@@ -57,6 +42,25 @@ func (d *DockerExecutor) PullImage(ctx context.Context, imageName, version strin
 
 		// Image doesn't exist, pull it
 		log.Info("image not found locally, pulling", "image", imageName)
+
+		done := make(chan struct{})
+		defer close(done)
+
+		if heartbeatFunc != nil {
+			go func() {
+				ticker := time.NewTicker(5 * time.Second)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ticker.C:
+						heartbeatFunc(ctx, fmt.Sprintf("pulling image %s", imageName))
+					case <-done:
+						return
+					}
+				}
+			}()
+		}
+
 		reader, err := d.client.ImagePull(pullCtx, imageName, client.ImagePullOptions{RegistryAuth: registryAuth()})
 		if err != nil {
 			if errors.Is(pullCtx.Err(), context.DeadlineExceeded) {
@@ -68,14 +72,7 @@ func (d *DockerExecutor) PullImage(ctx context.Context, imageName, version strin
 		}
 		defer reader.Close()
 
-		writer := &heartbeatWriter{
-			ctx:           ctx,
-			imageName:     imageName,
-			heartbeatFunc: heartbeatFunc,
-			lastHeartbeat: time.Now(),
-		}
-
-		if _, err = io.Copy(writer, reader); err != nil {
+		if _, err = io.Copy(io.Discard, reader); err != nil {
 			if errors.Is(pullCtx.Err(), context.DeadlineExceeded) {
 				log.Error("image pull timed out", "image", imageName)
 				return fmt.Errorf("image pull for %s timed out", imageName)

--- a/worker/executor/docker/container.go
+++ b/worker/executor/docker/container.go
@@ -33,7 +33,23 @@ type ContainerState struct {
 	ExitCode *int
 }
 
-func (d *DockerExecutor) PullImage(ctx context.Context, imageName, version string) error {
+type heartbeatWriter struct {
+	ctx           context.Context
+	imageName     string
+	heartbeatFunc func(context.Context, ...interface{})
+	lastHeartbeat time.Time
+}
+
+func (w *heartbeatWriter) Write(p []byte) (int, error) {
+	if w.heartbeatFunc != nil && time.Since(w.lastHeartbeat) > 5*time.Second {
+		w.heartbeatFunc(w.ctx, fmt.Sprintf("pulling image %s", w.imageName))
+		w.lastHeartbeat = time.Now()
+	}
+	return len(p), nil
+}
+
+
+func (d *DockerExecutor) PullImage(ctx context.Context, imageName, version string, heartbeatFunc func(context.Context, ...interface{})) error {
 	log := logger.Log(ctx)
 	_, err := d.client.ImageInspect(ctx, imageName)
 	if err != nil {
@@ -53,7 +69,14 @@ func (d *DockerExecutor) PullImage(ctx context.Context, imageName, version strin
 		}
 		defer reader.Close()
 
-		if _, err = io.Copy(io.Discard, reader); err != nil {
+		writer := &heartbeatWriter{
+			ctx:           ctx,
+			imageName:     imageName,
+			heartbeatFunc: heartbeatFunc,
+			lastHeartbeat: time.Now(),
+		}
+
+		if _, err = io.Copy(writer, reader); err != nil {
 			if errors.Is(pullCtx.Err(), context.DeadlineExceeded) {
 				log.Error("image pull timed out", "image", imageName)
 				return fmt.Errorf("image pull for %s timed out", imageName)

--- a/worker/executor/docker/executor.go
+++ b/worker/executor/docker/executor.go
@@ -49,7 +49,7 @@ func (d *DockerExecutor) Execute(ctx context.Context, req *types.ExecutionReques
 		}
 	}
 
-	if err := d.PullImage(ctx, imageName, req.Version); err != nil {
+	if err := d.PullImage(ctx, imageName, req.Version, req.HeartbeatFunc); err != nil {
 		log.Error("failed to pull image", "image", imageName, "error", err)
 		return "", err
 	}


### PR DESCRIPTION

# Description

This PR fixes a bug where `PullImage` blocked for up to 2 minutes during cold pulls, frequently tripping the 30-second Temporal `HeartbeatTimeout` and causing silent sync failures in Docker mode. 

It threads `req.HeartbeatFunc` down into `DockerExecutor.PullImage` and replaces the synchronous `io.Discard` copy with a custom `heartbeatWriter`. This pulses a heartbeat every 5 seconds synchronously from the pull stream, safely bypassing the Temporal timeout. Heartbeat return values are intentionally ignored since Temporal handles cancellations natively by aborting the context.

Fixes #203 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Ran a local test script by pulling `tensorflow/tensorflow:latest-gpu` (which takes >2 mins) and observed the custom `heartbeatWriter` successfully pulsing heartbeats every 5 seconds for the entire duration without triggering a context timeout.

# Screenshots or Recordings
<img width="773" height="240" alt="Screenshot 2026-09-11 191503" src="https://github.com/user-attachments/assets/01f2494b-da22-406f-b6bd-22d09494a9d9" />


## Documentation

- [ ] Documentation Link: [link to README, olake.io/docs, or olake-docs]
- [x] N/A (bug fix, refactor, or test changes only)


